### PR TITLE
fix missing AddRef on IUnknown extended properties

### DIFF
--- a/dll/MsRdpClient.cpp
+++ b/dll/MsRdpClient.cpp
@@ -511,10 +511,6 @@ public:
 
         hr = m_pMsTscAx->raw_Disconnect();
 
-        // Disconnect invalidates internal TSPropertySet pointers
-        CMsRdpExtendedSettings* pMsRdpExtendedSettings = m_pMsRdpExtendedSettings;
-        pMsRdpExtendedSettings->AttachRdpClient((IMsTscAx*)m_pMsTscAx);
-
         return hr;
     }
 

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -450,6 +450,10 @@ HRESULT __stdcall CMsRdpExtendedSettings::get_Property(BSTR bstrPropertyName, VA
         pValue->vt = VT_UNKNOWN;
         pValue->punkVal = NULL;
         hr = m_CoreProps->QueryInterface(IID_IUnknown, (LPVOID*) &pValue->punkVal);
+
+        if (pValue->punkVal) {
+            pValue->punkVal->AddRef();
+        }
     }
     else if (MsRdpEx_StringEquals(propName, "BaseProperties")) {
         if (!m_BaseProps) {
@@ -459,6 +463,10 @@ HRESULT __stdcall CMsRdpExtendedSettings::get_Property(BSTR bstrPropertyName, VA
         pValue->vt = VT_UNKNOWN;
         pValue->punkVal = NULL;
         hr = m_BaseProps->QueryInterface(IID_IUnknown, (LPVOID*)&pValue->punkVal);
+
+        if (pValue->punkVal) {
+            pValue->punkVal->AddRef();
+        }
     }
     else if (MsRdpEx_StringEquals(propName, "TransportProperties")) {
         if (!m_TransportProps) {
@@ -468,6 +476,10 @@ HRESULT __stdcall CMsRdpExtendedSettings::get_Property(BSTR bstrPropertyName, VA
         pValue->vt = VT_UNKNOWN;
         pValue->punkVal = NULL;
         hr = m_TransportProps->QueryInterface(IID_IUnknown, (LPVOID*)&pValue->punkVal);
+
+        if (pValue->punkVal) {
+            pValue->punkVal->AddRef();
+        }
     }
     else if (MsRdpEx_StringEquals(propName, "KDCProxyURL")) {
         pValue->vt = VT_BSTR;

--- a/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.csproj
+++ b/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Devolutions.MsRdpEx</AssemblyName>
     <PackageId>Devolutions.MsRdpEx</PackageId>
-    <Version>2022.10.11.0</Version>
+    <Version>2022.10.21.0</Version>
     <Authors>mamoreau@devolutions.net</Authors>
     <Company>Devolutions</Company>
     <Description>Microsoft RDP Extensions</Description>

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -2,6 +2,4 @@
 add_executable(MsRdpEx_Exe WIN32
 	MsRdpEx.c)
 
-set_target_properties(MsRdpEx_Exe PROPERTIES OUTPUT_NAME "MsRdpEx")
-
 target_link_libraries(MsRdpEx_Exe MsRdpEx_Dll)


### PR DESCRIPTION
Actually fix https://github.com/Devolutions/MsRdpEx/pull/65 properly

The issue was caused by missing AddRef when returning IUnknown objects to C# - when .NET disposed the COM object, it called Release(), which would cause the RefCount to go down to zero, and eventually freed the object.