### PR TITLE
Add MSRDPEX_CREDSSP_DLL environment variable

### DIFF
--- a/dll/String.c
+++ b/dll/String.c
@@ -130,6 +130,22 @@ bool MsRdpEx_StringIEquals(const char* str1, const char* str2)
     return _stricmp(str1, str2) == 0;
 }
 
+bool MsRdpEx_StringEqualsW(const WCHAR* str1, const WCHAR* str2)
+{
+    if (!str1 || !str2)
+        return false;
+
+    return wcscmp(str1, str2) == 0;
+}
+
+bool MsRdpEx_StringIEqualsW(const WCHAR* str1, const WCHAR* str2)
+{
+    if (!str1 || !str2)
+        return false;
+
+    return _wcsicmp(str1, str2) == 0;
+}
+
 bool MsRdpEx_StringStartsWith(const char* str, const char* val)
 {
     size_t strLen;

--- a/include/MsRdpEx/MsRdpEx.h
+++ b/include/MsRdpEx/MsRdpEx.h
@@ -85,6 +85,9 @@ int MsRdpEx_ConvertToUnicode(UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr
 bool MsRdpEx_StringEquals(const char* str1, const char* str2);
 bool MsRdpEx_StringIEquals(const char* str1, const char* str2);
 
+bool MsRdpEx_StringEqualsW(const WCHAR* str1, const WCHAR* str2);
+bool MsRdpEx_StringIEqualsW(const WCHAR* str1, const WCHAR* str2);
+
 bool MsRdpEx_StringStartsWith(const char* str, const char* val);
 bool MsRdpEx_IStringStartsWith(const char* str, const char* val);
 


### PR DESCRIPTION
Hook registry key APIs to return a different value than 'credssp.dll' for SecurityProviders under HKLM:\System\CurrentControlSet\Control\SecurityProviders. The file name still needs to be credssp.dll for it to work, but it's better than editing the registry globally on the system. I'll look into ways to work around the file name limitation. This works once per process, so only suitable for mstsc.exe at this point.