### PR TITLE
Add an option to connect to child session

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ MsRdpEx processes additional .RDP file options that are not normally supported b
 | RestrictedLogon:i:value | Enable Restricted Admin Mode | 0/1 | 0 |
 | UserSpecifiedServerName:s:value | Server name used for TLS and Kerberos server validation | explicit server name (usually the machine FQDN) | same as DNS hostname used for RDP server |
 | DisableUDPTransport:i:value | Disable RDP UDP transport (TCP only) | 0/1 | 0 | 
+| ConnectToChildSession:i:value | Connect to child session | 0/1 | 0 |
 | EnableHardwareMode:i:value | Disable DirectX client presenter (force GDI client presenter) | 0/1 | 1 |
 | ClearTextPassword:s:value | Target RDP server password - use for testing only | Insecure password | - |
 | GatewayPassword:s:value | RD Gateway server password - use for testing only | Insecure password | - |

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -698,6 +698,13 @@ HRESULT CMsRdpExtendedSettings::LoadRdpFile(const char* rdpFileName)
                     pMsRdpExtendedSettings->put_CoreProperty(propName, &value);
                 }
             }
+            else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "ConnectToChildSession")) {
+                VARIANT value;
+                if (MsRdpEx_RdpFileEntry_GetVBoolValue(entry, &value)) {
+                    bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
+                    pMsRdpExtendedSettings->put_CoreProperty(propName, &value);
+                }
+            }
             else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "EnableHardwareMode")) {
                 VARIANT value;
                 if (MsRdpEx_RdpFileEntry_GetVBoolValue(entry, &value)) {


### PR DESCRIPTION
This option is not available in a regular rdp file, but it's convenient for tests to have it handled by MsRdpEx.