### PR TITLE
Add RDP configurable mouse jiggler feature

### DIFF
--- a/dll/MsRdpClient.cpp
+++ b/dll/MsRdpClient.cpp
@@ -497,6 +497,7 @@ public:
         CMsRdpExtendedSettings* pMsRdpExtendedSettings = m_pMsRdpExtendedSettings;
         m_pMsRdpExtendedSettings->LoadRdpFile(NULL);
         m_pMsRdpExtendedSettings->PrepareSspiSessionIdHack();
+        m_pMsRdpExtendedSettings->PrepareMouseJiggler();
 
         hr = m_pMsTscAx->raw_Connect();
 

--- a/dll/RdpFile.c
+++ b/dll/RdpFile.c
@@ -53,7 +53,7 @@ bool MsRdpEx_RdpFileEntry_GetBoolValue(MsRdpEx_RdpFileEntry* entry, bool* pValue
 	return true;
 }
 
-bool MsRdpEx_RdpFileEntry_GetVBoolValue(MsRdpEx_RdpFileEntry* entry, VARIANT* pVariant)
+bool MsRdpEx_RdpFileEntry_GetVBoolValue(MsRdpEx_RdpFileEntry* entry, _Out_ VARIANT* pVariant)
 {
 	bool bVal = false;
 
@@ -63,6 +63,20 @@ bool MsRdpEx_RdpFileEntry_GetVBoolValue(MsRdpEx_RdpFileEntry* entry, VARIANT* pV
 	VariantInit(pVariant);
 	pVariant->vt = VT_BOOL;
 	pVariant->boolVal = bVal ? VARIANT_TRUE : VARIANT_FALSE;
+
+	return true;
+}
+
+bool MsRdpEx_RdpFileEntry_GetIntValue(MsRdpEx_RdpFileEntry* entry, _Out_ VARIANT* pVariant)
+{
+	if (entry->type != 'i')
+		return false;
+
+	int iValue = atoi(entry->value);
+
+	VariantInit(pVariant);
+	pVariant->vt = VT_I4;
+	pVariant->intVal = iValue;
 
 	return true;
 }
@@ -108,10 +122,18 @@ char* MsRdpEx_GetRdpFilenameFromCommandLine()
 		goto exit;
 	}
 
-	MsRdpEx_LogPrint(DEBUG, "cmdline(argc=%d): %s", argc, cmdlineA);
+	MsRdpEx_LogPrint(DEBUG, "cmdline(argc=%d): '%s'", argc, cmdlineA);
 
 	if (argc < 2)
 		goto exit;
+
+	for (index = 0; index < argc; index++)
+	{
+		char* argA = NULL;
+		MsRdpEx_ConvertFromUnicode(CP_UTF8, 0, argsW[index], -1, &argA, 0, NULL, NULL);
+		MsRdpEx_LogPrint(DEBUG, "arg[%d]: '%s'", index, argA);
+		free(argA);
+	}
 
 	if (MsRdpEx_ConvertFromUnicode(CP_UTF8, 0, argsW[1], -1, &filename, 0, NULL, NULL) < 0) {
 		goto exit;

--- a/dotnet/Devolutions.MsRdpEx/Bindings.cs
+++ b/dotnet/Devolutions.MsRdpEx/Bindings.cs
@@ -117,9 +117,15 @@ namespace MsRdpEx
 
         void SetCorePropsRawPtr(IntPtr pCorePropsRaw);
 
+        void AttachInputWindow(IntPtr hInputWnd, IntPtr pUserData);
+
         void AttachOutputWindow(IntPtr hOutputWnd, IntPtr pUserData);
 
         void AttachExtendedSettings(IntPtr pExtendedSettings);
+
+        [MethodImpl(MethodImplOptions.PreserveSig)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        bool GetExtendedSettings(out IntPtr ppExtendedSettings);
 
         [MethodImpl(MethodImplOptions.PreserveSig)]
         [return: MarshalAs(UnmanagedType.U1)]
@@ -131,6 +137,12 @@ namespace MsRdpEx
 
         [MethodImpl(MethodImplOptions.PreserveSig)]
         void UnlockShadowBitmap();
+
+        [MethodImpl(MethodImplOptions.PreserveSig)]
+        void GetLastMousePosition(ref Int32 posX, ref Int32 posY);
+
+        [MethodImpl(MethodImplOptions.PreserveSig)]
+        void SetLastMousePosition(Int32 posX, Int32 posY);
     }
 
     public static class Bindings

--- a/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.csproj
+++ b/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Devolutions.MsRdpEx</AssemblyName>
     <PackageId>Devolutions.MsRdpEx</PackageId>
-    <Version>2023.9.19.0</Version>
+    <Version>2023.9.28.0</Version>
     <Authors>mamoreau@devolutions.net</Authors>
     <Company>Devolutions</Company>
     <Description>Microsoft RDP Extensions</Description>

--- a/dotnet/MsRdpEx_App/MainDlg.cs
+++ b/dotnet/MsRdpEx_App/MainDlg.cs
@@ -351,6 +351,22 @@ namespace MsRdpEx_App
                             case "use redirection server name":
                                 redirectionInfo.UseRedirectionServerName = bValue;
                                 break;
+
+                            case "allowbackgroundinput":
+                                advancedSettings.allowBackgroundInput = bValue ? 1 : 0;
+                                break;
+
+                            case "enablemousejiggler":
+                                extendedSettings.set_Property("EnableMouseJiggler", bValue);
+                                break;
+
+                            case "mousejigglerinterval":
+                                extendedSettings.set_Property("MouseJigglerInterval", iValue);
+                                break;
+
+                            case "mousejigglermethod":
+                                extendedSettings.set_Property("MouseJigglerMethod", iValue);
+                                break;
                         }
                     }
                 }
@@ -369,17 +385,17 @@ namespace MsRdpEx_App
 
             if (externalMode)
             {
-                string filename = this.mstscExecutable;
+                string executableFileName = this.mstscExecutable;
 
                 if (axName.Equals("msrdc"))
                 {
-                    filename = this.msrdcExecutable;
+                    executableFileName = this.msrdcExecutable;
                 }
 
-                string workingDirectory = Path.GetDirectoryName(filename);
+                string workingDirectory = Path.GetDirectoryName(executableFileName);
 
                 List<string> args = new List<string>();
-                args.Add(filename);
+                args.Add('"' + executableFileName + '"');
 
                 if (this.rdpFileName != null)
                 {
@@ -389,7 +405,7 @@ namespace MsRdpEx_App
                 string arguments = string.Join(' ', args.ToArray());
 
                 ProcessStartInfo startInfo = new ProcessStartInfo();
-                startInfo.FileName = filename;
+                startInfo.FileName = executableFileName;
                 startInfo.UseShellExecute = false;
                 startInfo.WorkingDirectory = workingDirectory;
                 startInfo.Arguments = arguments;

--- a/include/MsRdpEx/RdpFile.h
+++ b/include/MsRdpEx/RdpFile.h
@@ -22,7 +22,8 @@ typedef struct _MsRdpEx_RdpFileEntry MsRdpEx_RdpFileEntry;
 bool MsRdpEx_RdpFileEntry_IsMatch(MsRdpEx_RdpFileEntry* entry, char type, const char* name);
 
 bool MsRdpEx_RdpFileEntry_GetBoolValue(MsRdpEx_RdpFileEntry* entry, bool* pValue);
-bool MsRdpEx_RdpFileEntry_GetVBoolValue(MsRdpEx_RdpFileEntry* entry, VARIANT* pVariant);
+bool MsRdpEx_RdpFileEntry_GetVBoolValue(MsRdpEx_RdpFileEntry* entry, _Out_ VARIANT* pVariant);
+bool MsRdpEx_RdpFileEntry_GetIntValue(MsRdpEx_RdpFileEntry* entry, _Out_ VARIANT* pVariant);
 
 MsRdpEx_RdpFileEntry* MsRdpEx_RdpFileEntry_New(char type, const char* name, const char* value);
 void MsRdpEx_RdpFileEntry_Free(MsRdpEx_RdpFileEntry* entry);

--- a/include/MsRdpEx/RdpInstance.h
+++ b/include/MsRdpEx/RdpInstance.h
@@ -23,12 +23,16 @@ public:
     virtual HRESULT __stdcall SetDumpBitmapUpdates(bool dumpBitmapUpdates) = 0;
     virtual HRESULT __stdcall GetCorePropsRawPtr(LPVOID* ppCorePropsRaw) = 0;
     virtual HRESULT __stdcall SetCorePropsRawPtr(LPVOID pCorePropsRaw) = 0;
+    virtual HRESULT __stdcall AttachInputWindow(HWND hOutputWnd, void* pUserData) = 0;
     virtual HRESULT __stdcall AttachOutputWindow(HWND hOutputWnd, void* pUserData) = 0;
     virtual HRESULT __stdcall AttachExtendedSettings(CMsRdpExtendedSettings* pExtendedSettings) = 0;
+    virtual bool __stdcall GetExtendedSettings(CMsRdpExtendedSettings** ppExtendedSettings) = 0;
     virtual bool __stdcall GetShadowBitmap(HDC* phDC, HBITMAP* phBitmap, uint8_t** pBitmapData,
         uint32_t* pBitmapWidth, uint32_t* pBitmapHeight, uint32_t* pBitmapStep) = 0;
     virtual void __stdcall LockShadowBitmap() = 0;
     virtual void __stdcall UnlockShadowBitmap() = 0;
+    virtual void __stdcall GetLastMousePosition(int32_t* posX, int32_t* posY) = 0;
+    virtual void __stdcall SetLastMousePosition(int32_t posX, int32_t posY) = 0;
 };
 
 class CMsRdpExInstance;
@@ -46,6 +50,10 @@ bool MsRdpEx_InstanceManager_Remove(CMsRdpExInstance* instance);
 CMsRdpExInstance* MsRdpEx_InstanceManager_FindByOutputPresenterHwnd(HWND hWnd);
 
 CMsRdpExInstance* MsRdpEx_InstanceManager_AttachOutputWindow(HWND hOutputWnd, void* pUserData);
+
+CMsRdpExInstance* MsRdpEx_InstanceManager_FindByInputCaptureHwnd(HWND hWnd);
+
+CMsRdpExInstance* MsRdpEx_InstanceManager_AttachInputWindow(HWND hInputWnd, void* pUserData);
 
 CMsRdpExInstance* MsRdpEx_InstanceManager_FindBySessionId(GUID* sessionId);
 

--- a/include/MsRdpEx/RdpSettings.h
+++ b/include/MsRdpEx/RdpSettings.h
@@ -7,6 +7,9 @@
 
 #include <comdef.h>
 
+#define MOUSE_JIGGLER_METHOD_MOUSE_MOVE         0
+#define MOUSE_JIGGLER_METHOD_SPECIAL_KEY        1
+
 class CMsRdpExtendedSettings;
 class CMsRdpPropertySet;
 
@@ -40,8 +43,12 @@ public:
     HRESULT __stdcall LoadRdpFile(const char* rdpFileName);
     HRESULT __stdcall GetCorePropsRawPtr(LPVOID* ppCorePropsRaw);
     HRESULT __stdcall PrepareSspiSessionIdHack();
+    HRESULT __stdcall PrepareMouseJiggler();
     char* __stdcall GetKdcProxyUrl();
     char* __stdcall GetKdcProxyName();
+    bool GetMouseJigglerEnabled();
+    uint32_t GetMouseJigglerInterval();
+    uint32_t GetMouseJigglerMethod();
 
 private:
     GUID m_sessionId;
@@ -54,6 +61,9 @@ private:
     CMsRdpPropertySet* m_BaseProps = NULL;
     CMsRdpPropertySet* m_TransportProps = NULL;
     char* m_KdcProxyUrl = NULL;
+    bool m_MouseJigglerEnabled = false;
+    uint32_t m_MouseJigglerInterval = 60;
+    uint32_t m_MouseJigglerMethod = 0;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
This pull requests adds a configurable RDP mouse jiggler feature directly into the RDP ActiveX, without using an extra background thread or process. We now hook the RDP input capture window in addition to the RDP output presenter window, and use it to register a WM_TIMER event that gets fired once every X seconds to either send a small mouse movement (+1, -1) or special key (F15) which is ignored by most applications.

There are three new .RDP file options:
- EnableMouseJiggler:i:1 - enable the mouse jiggler (disabled by default)
- MouseJigglerInterval:i:60 - set mouse jiggler interval in seconds (60 seconds by default)
- MouseJigglerMethod:i:0 set mouse jiggler method (0 = mouse move (default), 1 = special key (F15))

Corresponding RDP ActiveX options are exposed on IMsRdpExtendedSettings

For the event injection to work even when the RDP ActiveX window is not in focus, the [AllowBackgroundInput](https://learn.microsoft.com/en-us/windows/win32/termserv/imstscadvancedsettings-allowbackgroundinput) needs to be enabled. This option is exposed by the regular ActiveX interface, but there was no .RDP file option, so I added it (AllowBackgroundInput:i:1). However, to simplify usage, enabling the mouse jiggler will automatically allow background input.

In order to test the mouse jiggler, I suggest lowering the mouse jiggler interval to a small value like 3, and using the following PowerShell code snippet to print the last input time, with mstsc out of input focus:

```
Add-Type -TypeDefinition @"
    using System;
    using System.Runtime.InteropServices;

    public struct LASTINPUTINFO {
        public uint cbSize;
        public uint dwTime;
    }

    public class User32 {
        [DllImport("user32.dll", SetLastError = false)]
        public static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
    }
"@ -Language CSharp

while ($true) {
	Start-Sleep 1
	$lii = New-Object LASTINPUTINFO
	$lii.cbSize = [System.Runtime.InteropServices.Marshal]::SizeOf($lii)
	[void][User32]::GetLastInputInfo([ref]$lii)
	$LastInputInfoTime = $lii.dwTime
	Write-Host "LastInputInfoTime: $LastInputInfoTime"
}
```

You should normally see the last input info time change when the mouse jiggler interval expires, confirming that the injected input events have correctly simulated user activity inside the remote session. For the mouse jiggler using mouse movements, we capture the last mouse position inside the input capture window, and then use it to move the mouse by (+1, +1), and then back to the original position (-1, -1). In order to test that we don't cause a mouse drift, I have used the following code snippet:

```
Add-Type -AssemblyName System.Windows.Forms
while ($true) {
    $position = [System.Windows.Forms.Cursor]::Position
    Write-Output "Mouse X: $($position.X), Y: $($position.Y)"
    Start-Sleep -Seconds 1
}
```

You will most likely see the small mouse movements when the jiggle happens, but it will go back to its original position without drifting, confirming that it would not have unintended side effects beyond harmless mouse movements.

Regarding possible side effects of the mouse jiggler: if moving the mouse causes problems, use the special key input method instead (MouseJigglerMethod:i:1). If the special key input method causes problems, use the mouse movement instead. If both methods cause problems, then you likely have bigger problems, but you can always open a feature request here ;)