### PR TITLE
Fix most Unicode path handling problems except Detours

### DIFF
--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -1088,12 +1088,12 @@ LONG MsRdpEx_AttachHooks()
         return NO_ERROR;
     }
 
-    g_hNtDll = GetModuleHandleA("ntdll.dll");
+    g_hNtDll = GetModuleHandleW(L"ntdll.dll");
     MSRDPEX_GETPROCADDRESS(Real_LdrResolveDelayLoadedAPI, Func_LdrResolveDelayLoadedAPI, g_hNtDll, "LdrResolveDelayLoadedAPI");
     MSRDPEX_GETPROCADDRESS(Real_NtCreateFile, Func_NtCreateFile, g_hNtDll, "NtCreateFile");
     MSRDPEX_GETPROCADDRESS(Real_NtOpenFile, Func_NtOpenFile, g_hNtDll, "NtOpenFile");
 
-    g_hKernelBase = GetModuleHandleA("KernelBase.dll");
+    g_hKernelBase = GetModuleHandleW(L"KernelBase.dll");
     MSRDPEX_GETPROCADDRESS(Real_RegOpenKeyExW, Func_RegOpenKeyExW, g_hKernelBase, "RegOpenKeyExW");
     MSRDPEX_GETPROCADDRESS(Real_RegQueryValueExW, Func_RegQueryValueExW, g_hKernelBase, "RegQueryValueExW");
     MSRDPEX_GETPROCADDRESS(Real_RegCloseKey, Func_RegCloseKey, g_hKernelBase, "RegCloseKey");

--- a/dll/Log.c
+++ b/dll/Log.c
@@ -174,7 +174,7 @@ void MsRdpEx_LogOpen()
         sprintf_s(g_LogFilePath, MSRDPEX_MAX_PATH, "%s\\MsRdpEx.log", appDataPath);
     }
 
-    g_LogFile = fopen(g_LogFilePath, "wb");
+    g_LogFile = MsRdpEx_FileOpen(g_LogFilePath, "wb");
 }
 
 void MsRdpEx_LogClose()

--- a/dll/Sspi.cpp
+++ b/dll/Sspi.cpp
@@ -764,12 +764,12 @@ static SECURITY_STATUS SEC_ENTRY sspi_QueryCredentialsAttributesExW(PCredHandle 
 
 LONG MsRdpEx_AttachSspiHooks()
 {
-	g_hSspiCli = GetModuleHandleA("sspicli.dll");
+	g_hSspiCli = GetModuleHandleW(L"sspicli.dll");
 
 	if (!g_hSspiCli)
 		return -1;
 
-	g_hSecur32 = GetModuleHandleA("secur32.dll");
+	g_hSecur32 = GetModuleHandleW(L"secur32.dll");
 
 	if (!g_hSecur32)
 		return -1;

--- a/dll/String.c
+++ b/dll/String.c
@@ -636,6 +636,33 @@ char* MsRdpEx_CloneStringBlock(const char* argb)
     return copyb;
 }
 
+WCHAR* MsRdpEx_ConvertStringBlockToUnicode(const char* argb)
+{
+    int length = 0;
+    size_t size = 0;
+    char* arg = NULL;
+    char** args = NULL;
+    WCHAR* copyb = NULL;
+
+    if (!argb)
+        return NULL;
+
+    arg = (char*)argb;
+    do
+    {
+        length = strlen(arg);
+        arg = &arg[length + 1];
+        size += (length + 1);
+    } while (length > 0);
+    size += 1;
+
+    if (MsRdpEx_ConvertToUnicode(CP_UTF8, 0, argb, size, &copyb, 0) < 1) {
+        return NULL;
+    }
+
+    return copyb;
+}
+
 void MsRdpEx_FreeStringBlock(const char* argb)
 {
     free((void*) argb);

--- a/include/MsRdpEx/MsRdpEx.h
+++ b/include/MsRdpEx/MsRdpEx.h
@@ -119,6 +119,7 @@ char* MsRdpEx_StringJoin(char* value[], size_t count, const char sep);
 char** MsRdpEx_GetStringVectorFromBlock(int* argc, const char* argb);
 char* MsRdpEx_GetStringBlockFromVector(int argc, char** argv);
 char* MsRdpEx_CloneStringBlock(const char* argb);
+WCHAR* MsRdpEx_ConvertStringBlockToUnicode(const char* argb);
 void MsRdpEx_FreeStringBlock(const char* argb);
 void MsRdpEx_FreeStringVector(int argc, char** argv);
 


### PR DESCRIPTION
Fixes most Unicode path handling problems (https://github.com/Devolutions/MsRdpEx/issues/94)

The only issue left is if MsRdpEx itself is installed in a non-ASCII path, because of an issue with Detours being unable to inject a DLL with proper Unicode handling (https://github.com/microsoft/Detours/issues/283).
