### PR TITLE
fix UTF-8 string marshalling

### DIFF
--- a/dotnet/Devolutions.MsRdpEx/Bindings.cs
+++ b/dotnet/Devolutions.MsRdpEx/Bindings.cs
@@ -178,7 +178,7 @@ namespace MsRdpEx
 
             for (int i = 0; i < argc; i++)
             {
-                argv[i] = Marshal.StringToCoTaskMemAnsi(args[i]);
+                argv[i] = MarshalHelpers.StringToCoTaskMemUTF8(args[i]);
             }
 
             process.Start(argc, ref argv, appName, axName);

--- a/dotnet/Devolutions.MsRdpEx/MarshalHelpers.cs
+++ b/dotnet/Devolutions.MsRdpEx/MarshalHelpers.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Net.NetworkInformation;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace MsRdpEx
+{
+    public class MarshalHelpers
+    {
+        // Replacement for Marshal.PtrToStringUTF8
+        public static string PtrToStringUTF8(IntPtr ptr)
+        {
+            int length = 0;
+            while (Marshal.ReadByte(ptr, length) != 0)
+            {
+                length++;
+            }
+
+            byte[] buffer = new byte[length];
+            Marshal.Copy(ptr, buffer, 0, length);
+
+            return System.Text.Encoding.UTF8.GetString(buffer);
+        }
+
+        // Replacement for Marshal.StringToCoTaskMemUTF8
+        public static IntPtr StringToCoTaskMemUTF8(string str)
+        {
+            if (str == null)
+            {
+                return IntPtr.Zero;
+            }
+
+            byte[] utf8Bytes = System.Text.Encoding.UTF8.GetBytes(str);
+            IntPtr unmanagedMemory = Marshal.AllocCoTaskMem(utf8Bytes.Length + 1);
+            Marshal.Copy(utf8Bytes, 0, unmanagedMemory, utf8Bytes.Length);
+            Marshal.WriteByte(unmanagedMemory, utf8Bytes.Length, 0);
+
+            return unmanagedMemory;
+        }
+    }
+}

--- a/dotnet/Devolutions.MsRdpEx/RdpCoreApi.cs
+++ b/dotnet/Devolutions.MsRdpEx/RdpCoreApi.cs
@@ -24,7 +24,7 @@ namespace MsRdpEx
 
         public string MsRdpExDllPath
         {
-            get { return Marshal.PtrToStringAnsi(iface.GetMsRdpExDllPath()); }
+            get { return MarshalHelpers.PtrToStringUTF8(iface.GetMsRdpExDllPath()); }
         }
 
         public bool LogEnabled


### PR DESCRIPTION
Add compatible replacements for Marshal.PtrToStringUTF8 and Marshal.StringToCoTaskMemUTF8 that aren't available in netstandard2.0, and remove UTF-8 incompatible calls to Marshal.PtrToStringAnsi, Marshal.StringToCoTaskMemAnsi.