### PR TITLE
session recording improvements

### DIFF
--- a/dll/AxHost/RdpComBase.h
+++ b/dll/AxHost/RdpComBase.h
@@ -1,21 +1,9 @@
-#ifndef MSRDPEX_COM_HELPER_H
-#define MSRDPEX_COM_HELPER_H
+#ifndef MSRDPEX_COM_BASE_H
+#define MSRDPEX_COM_BASE_H
 
-#include <MsRdpEx/MsRdpEx.h>
-
-#include <atlbase.h>
-#include <oleidl.h>
-#include <commctrl.h>
-
-#ifndef SafeRelease
-#define SafeRelease(_x) { if ((_x) != nullptr) { (_x)->Release(); (_x) = nullptr; } }
-#endif
-
-#ifndef ToVariantBool
-#define ToVariantBool(_b) ((_b) ? VARIANT_TRUE : VARIANT_FALSE)
-#endif
+#include "../ComHelpers.h"
 
 #include "../com/mstscax.tlh"
 using namespace MSTSCLib;
 
-#endif /* MSRDPEX_COM_HELPER_H */
+#endif /* MSRDPEX_COM_BASE_H */

--- a/dll/ComHelpers.h
+++ b/dll/ComHelpers.h
@@ -1,0 +1,25 @@
+#ifndef MSRDPEX_COM_HELPERS_H
+#define MSRDPEX_COM_HELPERS_H
+
+#include <MsRdpEx/MsRdpEx.h>
+
+#include <atlbase.h>
+#include <oleidl.h>
+#include <commctrl.h>
+
+#ifndef SafeRelease
+#define SafeRelease(_x) { if ((_x) != nullptr) { (_x)->Release(); (_x) = nullptr; } }
+#endif
+
+#ifndef ToVariantBool
+#define ToVariantBool(_b) ((_b) ? VARIANT_TRUE : VARIANT_FALSE)
+#endif
+
+#define VariantInitBool(pv, b)                            \
+    do {                                                  \
+        VariantInit((pv));                                \
+        (pv)->vt = VT_BOOL;                               \
+        (pv)->boolVal = ((b) ? VARIANT_TRUE : VARIANT_FALSE); \
+    } while (0)
+
+#endif /* MSRDPEX_COM_HELPERS_H */

--- a/dll/File.c
+++ b/dll/File.c
@@ -33,6 +33,33 @@ const char* MsRdpEx_FileBase(const char* filename)
     return filename;
 }
 
+char* MsRdpEx_FileDir(const char* filename)
+{
+	size_t length;
+	char* separator;
+
+	if (!filename)
+		return NULL;
+
+	separator = strrchr(filename, '\\');
+
+	if (!separator)
+		separator = strrchr(filename, '/');
+
+	if (!separator)
+		return NULL;
+
+	length = (separator - filename) + 1; // include the separator
+	char* dirname = (char*)malloc(length + 1);
+	if (!dirname)
+		return NULL;
+
+	memcpy(dirname, filename, length);
+	dirname[length] = '\0';
+
+	return dirname;
+}
+
 bool MsRdpEx_FileExists(const char* filename)
 {
     bool result = false;
@@ -239,6 +266,32 @@ bool MsRdpEx_MakePath(const char* path, LPSECURITY_ATTRIBUTES lpAttributes)
 exit:
 	free(pathW);
     return result;
+}
+
+BOOL MsRdpEx_MoveFile(LPCSTR lpExistingFileName, LPCSTR lpNewFileName, DWORD flags)
+{
+	BOOL result = FALSE;
+	LPWSTR lpExistingFileNameW = NULL;
+	LPWSTR lpNewFileNameW = NULL;
+
+	if (!lpExistingFileName)
+		goto cleanup;
+
+	if (MsRdpEx_ConvertToUnicode(CP_UTF8, 0, lpExistingFileName, -1, &lpExistingFileNameW, 0) < 1)
+		goto cleanup;
+
+	if (lpNewFileName)
+	{
+		if (MsRdpEx_ConvertToUnicode(CP_UTF8, 0, lpNewFileName, -1, &lpNewFileNameW, 0) < 1)
+			goto cleanup;
+	}
+
+	result = MoveFileExW(lpExistingFileNameW, lpNewFileNameW, flags);
+
+cleanup:
+	free(lpExistingFileNameW);
+	free(lpNewFileNameW);
+	return result;
 }
 
 uint64_t MsRdpEx_GetUnixTime()

--- a/dll/MsRdpClient.cpp
+++ b/dll/MsRdpClient.cpp
@@ -205,7 +205,10 @@ public:
         }
         
         if (m_pMsRdpExInstance) {
+            IMsRdpExInstance* pMsRdpExInstance = (IMsRdpExInstance*)m_pMsRdpExInstance;
             MsRdpEx_InstanceManager_Remove(m_pMsRdpExInstance);
+            pMsRdpExInstance->Release();
+            pMsRdpExInstance = NULL;
         }
     }
 
@@ -499,6 +502,7 @@ public:
         m_pMsRdpExtendedSettings->LoadRdpFileFromNamedPipe(NULL);
         m_pMsRdpExtendedSettings->PrepareSspiSessionIdHack();
         m_pMsRdpExtendedSettings->PrepareMouseJiggler();
+        m_pMsRdpExtendedSettings->PrepareVideoRecorder();
         m_pMsRdpExtendedSettings->PrepareExtraSystemMenu();
 
         hr = m_pMsTscAx->raw_Connect();

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -20,10 +20,13 @@ struct _MsRdpEx_OutputMirror
 	HGDIOBJ hShadowObject;
 	uint32_t captureIndex;
 	uint64_t captureBaseTime;
-	char capturePath[MSRDPEX_MAX_PATH];
 
+	int videoRecordingCount;
 	bool dumpBitmapUpdates;
 	bool videoRecordingEnabled;
+	uint32_t videoQualityLevel;
+	char recordingPath[MSRDPEX_MAX_PATH];
+	char sessionId[MSRDPEX_GUID_STRING_SIZE];
 	MsRdpEx_VideoRecorder* videoRecorder;
 	FILE* frameMetadataFile;
 
@@ -84,7 +87,7 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx)
 	if (ctx->dumpBitmapUpdates) {
 		char metadata[1024];
 
-		sprintf_s(filename, MSRDPEX_MAX_PATH, "%s\\frame_%04d.bmp", ctx->capturePath, ctx->captureIndex);
+		sprintf_s(filename, MSRDPEX_MAX_PATH, "%s\\%s\\frame_%04d.bmp", ctx->recordingPath, ctx->sessionId, ctx->captureIndex);
 		MsRdpEx_WriteBitmapFile(filename, ctx->bitmapData, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitsPerPixel);
 
 		sprintf_s(metadata, sizeof(metadata), "%llu|%dx%d|%s|%dx%d|%dx%d\n",
@@ -107,6 +110,21 @@ void MsRdpEx_OutputMirror_SetDumpBitmapUpdates(MsRdpEx_OutputMirror* ctx, bool d
 void MsRdpEx_OutputMirror_SetVideoRecordingEnabled(MsRdpEx_OutputMirror* ctx, bool videoRecordingEnabled)
 {
 	ctx->videoRecordingEnabled = videoRecordingEnabled;
+}
+
+void MsRdpEx_OutputMirror_SetVideoQualityLevel(MsRdpEx_OutputMirror* ctx, uint32_t videoQualityLevel)
+{
+	ctx->videoQualityLevel = videoQualityLevel;
+}
+
+void MsRdpEx_OutputMirror_SetRecordingPath(MsRdpEx_OutputMirror* ctx, const char* recordingPath)
+{
+	strcpy_s(ctx->recordingPath, MSRDPEX_MAX_PATH, recordingPath);
+}
+
+void MsRdpEx_OutputMirror_SetSessionId(MsRdpEx_OutputMirror* ctx, const char* sessionId)
+{
+	strcpy_s(ctx->sessionId, MSRDPEX_GUID_STRING_SIZE, sessionId);
 }
 
 bool MsRdpEx_OutputMirror_GetShadowBitmap(MsRdpEx_OutputMirror* ctx,
@@ -143,43 +161,45 @@ bool MsRdpEx_OutputMirror_Init(MsRdpEx_OutputMirror* ctx)
 
 	ctx->captureBaseTime = GetTickCount64();
 
-	char* capturePath = MsRdpEx_GetEnv("MSRDPEX_CAPTURE_PATH");
+	char* envRecordingPath = MsRdpEx_GetEnv("MSRDPEX_RECORDING_PATH");
+	if (envRecordingPath) {
+		MsRdpEx_OutputMirror_SetRecordingPath(ctx, envRecordingPath);
+		free(envRecordingPath);
+	}
 
-	if (capturePath) {
-		strcpy_s(ctx->capturePath, MSRDPEX_MAX_PATH, capturePath);
-		free(capturePath);
-	} else {
+	if (MsRdpEx_StringIsNullOrEmpty(ctx->recordingPath)) {
 		const char* appDataPath = MsRdpEx_GetPath(MSRDPEX_APP_DATA_PATH);
-		sprintf_s(ctx->capturePath, MSRDPEX_MAX_PATH, "%s\\capture", appDataPath);
+		sprintf_s(ctx->recordingPath, MSRDPEX_MAX_PATH, "%s\\recordings", appDataPath);
+	}
+
+	if (MsRdpEx_StringIsNullOrEmpty(ctx->sessionId)) {
+		GUID guid;
+		MsRdpEx_GuidGenerate(&guid);
+		MsRdpEx_GuidBinToStr((GUID*)&guid, ctx->sessionId, 0);
 	}
 
 	if (ctx->videoRecordingEnabled) {
+		char outputPath[MSRDPEX_MAX_PATH];
 		char filename[MSRDPEX_MAX_PATH];
-		uint64_t timestamp = MsRdpEx_GetUnixTime();
 
-		MsRdpEx_MakePath(ctx->capturePath, NULL);
+		sprintf_s(outputPath, MSRDPEX_MAX_PATH, "%s\\%s", ctx->recordingPath, ctx->sessionId);
+		MsRdpEx_MakePath(outputPath, NULL);
 
 		ctx->videoRecorder = MsRdpEx_VideoRecorder_New();
 
 		if (ctx->videoRecorder) {
-			char* videoFileName = MsRdpEx_GetEnv("MSRDPEX_VIDEO_FILENAME");
-
-			if (videoFileName) {
-				strcpy_s(filename, MSRDPEX_MAX_PATH, videoFileName);
-				free(videoFileName);
-			} else {
-				sprintf_s(filename, MSRDPEX_MAX_PATH, "%s\\%llu.webm", ctx->capturePath, timestamp);
-			}
-
+			sprintf_s(filename, MSRDPEX_MAX_PATH, "%s\\recording-%d.webm", outputPath, ctx->videoRecordingCount);
+			ctx->videoRecordingCount++;
 			MsRdpEx_VideoRecorder_SetFrameSize(ctx->videoRecorder, ctx->bitmapWidth, ctx->bitmapHeight);
 			MsRdpEx_VideoRecorder_SetFileName(ctx->videoRecorder, filename);
+			MsRdpEx_VideoRecorder_SetVideoQuality(ctx->videoRecorder, ctx->videoQualityLevel);
 			MsRdpEx_VideoRecorder_Init(ctx->videoRecorder);
 		}
 
 		if (ctx->dumpBitmapUpdates) {
 			char metadata[1024];
 			sprintf_s(metadata, sizeof(metadata), "FrameTime|FrameSize|FrameFile|UpdatePos|UpdateSize\n");
-			sprintf_s(filename, MSRDPEX_MAX_PATH, "%s\\frame_meta.psv", ctx->capturePath);
+			sprintf_s(filename, MSRDPEX_MAX_PATH, "%s\\frame_meta.psv", outputPath);
 			ctx->frameMetadataFile = MsRdpEx_FileOpen(filename, "wb");
 			fwrite(metadata, 1, strlen(metadata), ctx->frameMetadataFile);
 		}
@@ -206,6 +226,7 @@ bool MsRdpEx_OutputMirror_Uninit(MsRdpEx_OutputMirror* ctx)
 
 	if (ctx->videoRecorder) {
 		MsRdpEx_VideoRecorder_Uninit(ctx->videoRecorder);
+		MsRdpEx_VideoRecorder_Remux(ctx->videoRecorder, NULL);
 		MsRdpEx_VideoRecorder_Free(ctx->videoRecorder);
 		ctx->videoRecorder = NULL;
 	}
@@ -229,6 +250,7 @@ MsRdpEx_OutputMirror* MsRdpEx_OutputMirror_New()
 
 	ctx->bitsPerPixel = 32;
 	ctx->videoRecordingEnabled = false;
+	ctx->videoQualityLevel = 5;
 	ctx->dumpBitmapUpdates = false;
 
     InitializeCriticalSectionAndSpinCount(&ctx->lock, 4000);

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -6,6 +6,7 @@
 #include <MsRdpEx/Environment.h>
 
 #include "TSObjects.h"
+#include "ComHelpers.h"
 
 extern "C" const GUID IID_IMsRdpExInstance;
 
@@ -21,10 +22,6 @@ public:
         char sessionId[MSRDPEX_GUID_STRING_SIZE];
         MsRdpEx_GuidBinToStr((GUID*)&m_sessionId, sessionId, 0);
         MsRdpEx_LogPrint(DEBUG, "CMsRdpExInstance SessionId: %s", sessionId);
-
-        m_outputMirrorEnabled = MsRdpEx_GetEnvBool("MSRDPEX_OUTPUT_MIRROR_ENABLED", false);
-        m_videoRecordingEnabled = MsRdpEx_GetEnvBool("MSRDPEX_VIDEO_RECORDING_ENABLED", false);
-        m_dumpBitmapUpdates = MsRdpEx_GetEnvBool("MSRDPEX_DUMP_BITMAP_UPDATES", false);
     }
 
     ~CMsRdpExInstance()
@@ -120,44 +117,66 @@ public:
 
     HRESULT STDMETHODCALLTYPE GetOutputMirrorEnabled(bool* outputMirrorEnabled)
     {
-        *outputMirrorEnabled = m_outputMirrorEnabled;
+        if (!m_pMsRdpExtendedSettings)
+            return E_UNEXPECTED;
+
+        *outputMirrorEnabled = m_pMsRdpExtendedSettings->GetOutputMirrorEnabled();
         return S_OK;
     }
 
     HRESULT STDMETHODCALLTYPE SetOutputMirrorEnabled(bool outputMirrorEnabled)
     {
-        m_outputMirrorEnabled = outputMirrorEnabled;
+        if (!m_pMsRdpExtendedSettings)
+            return E_UNEXPECTED;
+
+        VARIANT propValue;
+        VariantInitBool(&propValue, outputMirrorEnabled);
+        bstr_t propName = _com_util::ConvertStringToBSTR("OutputMirrorEnabled");
+        m_pMsRdpExtendedSettings->put_Property(propName, &propValue);
+
         return S_OK;
     }
 
     HRESULT STDMETHODCALLTYPE GetVideoRecordingEnabled(bool* videoRecordingEnabled)
     {
-        *videoRecordingEnabled = m_videoRecordingEnabled;
+        if (!m_pMsRdpExtendedSettings)
+            return E_UNEXPECTED;
+
+        *videoRecordingEnabled = m_pMsRdpExtendedSettings->GetVideoRecordingEnabled();
         return S_OK;
     }
 
     HRESULT STDMETHODCALLTYPE SetVideoRecordingEnabled(bool videoRecordingEnabled)
     {
-        m_videoRecordingEnabled = videoRecordingEnabled;
+        if (!m_pMsRdpExtendedSettings)
+            return E_UNEXPECTED;
 
-        if (videoRecordingEnabled)
-            m_outputMirrorEnabled = true;
+        VARIANT propValue;
+        VariantInitBool(&propValue, videoRecordingEnabled);
+        bstr_t propName = _com_util::ConvertStringToBSTR("VideoRecordingEnabled");
+        m_pMsRdpExtendedSettings->put_Property(propName, &propValue);
 
         return S_OK;
     }
 
     HRESULT STDMETHODCALLTYPE GetDumpBitmapUpdates(bool* dumpBitmapUpdates)
     {
-        *dumpBitmapUpdates = m_dumpBitmapUpdates;
+        if (!m_pMsRdpExtendedSettings)
+            return E_UNEXPECTED;
+
+        *dumpBitmapUpdates = m_pMsRdpExtendedSettings->GetDumpBitmapUpdates();
         return S_OK;
     }
 
     HRESULT STDMETHODCALLTYPE SetDumpBitmapUpdates(bool dumpBitmapUpdates)
     {
-        m_dumpBitmapUpdates = dumpBitmapUpdates;
+        if (!m_pMsRdpExtendedSettings)
+            return E_UNEXPECTED;
 
-        if (dumpBitmapUpdates)
-            m_outputMirrorEnabled = true;
+        VARIANT propValue;
+        VariantInitBool(&propValue, dumpBitmapUpdates);
+        bstr_t propName = _com_util::ConvertStringToBSTR("DumpBitmapUpdates");
+        m_pMsRdpExtendedSettings->put_Property(propName, &propValue);
 
         return S_OK;
     }
@@ -282,9 +301,6 @@ public:
 public:
     GUID m_sessionId;
     ULONG m_refCount = NULL;
-    bool m_outputMirrorEnabled = false;
-    bool m_videoRecordingEnabled = false;
-    bool m_dumpBitmapUpdates = false;
     CMsRdpClient* m_pMsRdpClient = NULL;
     HWND m_hInputCaptureWnd = NULL;
     HWND m_hOutputPresenterWnd = NULL;

--- a/dll/String.c
+++ b/dll/String.c
@@ -270,6 +270,17 @@ bool MsRdpEx_IStringEndsWithW(const WCHAR* str, const WCHAR* val)
     return false;
 }
 
+bool MsRdpEx_StringIsNullOrEmpty(const char* str)
+{
+    if (!str)
+        return true;
+
+    if (strlen(str) < 1)
+        return true;
+
+    return false;
+}
+
 static GUID GUID_NIL =
 {
 	0x00000000, 0x0000, 0x0000,

--- a/dll/VideoRecorder.c
+++ b/dll/VideoRecorder.c
@@ -18,20 +18,19 @@ MsRdpEx_VideoRecorder* MsRdpEx_VideoRecorder_New()
 {
     HMODULE hModule;
     MsRdpEx_VideoRecorder* ctx;
-    char* libraryPath = MsRdpEx_GetEnv("MSRDPEX_XMF_DLL");
+    const char* libPath = MsRdpEx_GetPath(MSRDPEX_XMF_DLL_PATH);
 
-    if (!libraryPath) {
-        libraryPath = _strdup("xmf.dll");
-    }
-
-    hModule = MsRdpEx_LoadLibrary(libraryPath);
-
-    if (!hModule) {
-        MsRdpEx_LogPrint(DEBUG, "LoadLibrary(%s): not found", libraryPath);
+    if (MsRdpEx_StringIsNullOrEmpty(libPath)) {
+        MsRdpEx_LogPrint(DEBUG, "no xmf.dll (cadeau) library detected");
         return NULL;
     }
 
-    free(libraryPath);
+    hModule = MsRdpEx_LoadLibrary(libPath);
+
+    if (!hModule) {
+        MsRdpEx_LogPrint(DEBUG, "Could not load cadeau library: '%s'", libPath);
+        return NULL;
+    }
 
     ctx = (MsRdpEx_VideoRecorder*) malloc(sizeof(MsRdpEx_VideoRecorder));
 
@@ -41,6 +40,7 @@ MsRdpEx_VideoRecorder* MsRdpEx_VideoRecorder_New()
     ZeroMemory(ctx, sizeof(MsRdpEx_VideoRecorder));
 
     ctx->hModule = hModule;
+
     MsRdpEx_LoadFunc(hModule, "XmfRecorder_New", (void**)&ctx->Recorder_New);
     MsRdpEx_LoadFunc(hModule, "XmfRecorder_Init", (void**)&ctx->Recorder_Init);
     MsRdpEx_LoadFunc(hModule, "XmfRecorder_Uninit", (void**)&ctx->Recorder_Uninit);
@@ -50,8 +50,12 @@ MsRdpEx_VideoRecorder* MsRdpEx_VideoRecorder_New()
     MsRdpEx_LoadFunc(hModule, "XmfRecorder_SetFileName", (void**)&ctx->Recorder_SetFileName);
     MsRdpEx_LoadFunc(hModule, "XmfRecorder_UpdateFrame", (void**)&ctx->Recorder_UpdateFrame);
     MsRdpEx_LoadFunc(hModule, "XmfRecorder_Timeout", (void**)&ctx->Recorder_Timeout);
-    MsRdpEx_LoadFunc(hModule, "XmfRecorder_GetTimeoust", (void**)&ctx->Recorder_GetTimeout);
+    MsRdpEx_LoadFunc(hModule, "XmfRecorder_GetTimeout", (void**)&ctx->Recorder_GetTimeout);
     MsRdpEx_LoadFunc(hModule, "XmfRecorder_Free", (void**)&ctx->Recorder_Free);
+
+    MsRdpEx_LoadFunc(hModule, "XmfWebMMuxer_New", (void**)&ctx->XmfWebMMuxer_New);
+    MsRdpEx_LoadFunc(hModule, "XmfWebMMuxer_Remux", (void**)&ctx->XmfWebMMuxer_Remux);
+    MsRdpEx_LoadFunc(hModule, "XmfWebMMuxer_Free", (void**)&ctx->XmfWebMMuxer_Free);
 
     ctx->recorder = ctx->Recorder_New();
 
@@ -100,6 +104,8 @@ void MsRdpEx_VideoRecorder_SetVideoQuality(MsRdpEx_VideoRecorder* ctx, uint32_t 
 
 void MsRdpEx_VideoRecorder_SetFileName(MsRdpEx_VideoRecorder* ctx, const char* filename)
 {
+    strcpy_s(ctx->filename, MSRDPEX_MAX_PATH, filename);
+
     if (ctx->Recorder_SetFileName) {
         ctx->Recorder_SetFileName(ctx->recorder, filename);
     }
@@ -129,6 +135,32 @@ uint32_t MsRdpEx_VideoRecorder_GetTimeout(MsRdpEx_VideoRecorder* ctx)
     }
 
     return 0;
+}
+
+bool MsRdpEx_VideoRecorder_Remux(MsRdpEx_VideoRecorder* ctx, const char* filename)
+{
+    char tempFile[MSRDPEX_MAX_PATH];
+
+    if (!filename)
+        filename = ctx->filename;
+
+    if (!MsRdpEx_FileExists(filename))
+        return false;
+
+    if (!(ctx->XmfWebMMuxer_New && ctx->XmfWebMMuxer_Remux && ctx->XmfWebMMuxer_Free))
+        return false;
+
+    XmfWebMMuxer* muxer = ctx->XmfWebMMuxer_New();
+
+    if (!muxer)
+        return false;
+
+    sprintf_s(tempFile, MSRDPEX_MAX_PATH, "%s.tmp", filename);
+    ctx->XmfWebMMuxer_Remux(muxer, filename, tempFile);
+    MsRdpEx_MoveFile(tempFile, filename, MOVEFILE_REPLACE_EXISTING);
+    ctx->XmfWebMMuxer_Free(muxer);
+
+    return true;
 }
 
 void MsRdpEx_VideoRecorder_Free(MsRdpEx_VideoRecorder* ctx)

--- a/include/MsRdpEx/MsRdpEx.h
+++ b/include/MsRdpEx/MsRdpEx.h
@@ -37,6 +37,7 @@ extern "C" {
 #endif
 
 const char* MsRdpEx_FileBase(const char* filename);
+char* MsRdpEx_FileDir(const char* filename);
 bool MsRdpEx_FileExists(const char* filename);
 
 FILE* MsRdpEx_FileOpen(const char* path, const char* mode);
@@ -48,6 +49,7 @@ uint64_t MsRdpEx_FileSize(const char* filename);
 
 bool MsRdpEx_GetFileBuildVersion(const char* filename, uint64_t* version);
 bool MsRdpEx_MakePath(const char* path, LPSECURITY_ATTRIBUTES lpAttributes);
+BOOL MsRdpEx_MoveFile(LPCSTR lpExistingFileName, LPCSTR lpNewFileName, DWORD flags);
 
 uint64_t MsRdpEx_GetUnixTime();
 
@@ -65,6 +67,9 @@ HMODULE MsRdpEx_LoadLibrary(const char* filename);
 #define MSRDPEX_MSRDC_EXE_PATH          0x00000400
 #define MSRDPEX_RDCLIENTAX_DLL_PATH     0x00000800
 #define MSRDPEX_DEFAULT_RDP_PATH        0x00001000
+#define MSRDPEX_MODULE_DIR_PATH         0x00002000
+#define MSRDPEX_LIBRARY_DIR_PATH        0x00004000
+#define MSRDPEX_XMF_DLL_PATH            0x00008000
 #define MSRDPEX_ALL_PATHS               0xFFFFFFFF
 
 bool MsRdpEx_InitPaths(uint32_t pathIds);
@@ -96,6 +101,8 @@ bool MsRdpEx_StringEndsWith(const char* str, const char* val);
 bool MsRdpEx_IStringEndsWith(const char* str, const char* val);
 
 bool MsRdpEx_IStringEndsWithW(const WCHAR* str, const WCHAR* val);
+
+bool MsRdpEx_StringIsNullOrEmpty(const char* str);
 
 #define MSRDPEX_STRING_FLAG_UPPERCASE       0x00000001
 #define MSRDPEX_STRING_FLAG_NO_TERMINATOR   0x00000002

--- a/include/MsRdpEx/OutputMirror.h
+++ b/include/MsRdpEx/OutputMirror.h
@@ -21,6 +21,9 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx);
 
 void MsRdpEx_OutputMirror_SetDumpBitmapUpdates(MsRdpEx_OutputMirror* ctx, bool dumpBitmapUpdates);
 void MsRdpEx_OutputMirror_SetVideoRecordingEnabled(MsRdpEx_OutputMirror* ctx, bool videoRecordingEnabled);
+void MsRdpEx_OutputMirror_SetVideoQualityLevel(MsRdpEx_OutputMirror* ctx, uint32_t videoQualityLevel);
+void MsRdpEx_OutputMirror_SetRecordingPath(MsRdpEx_OutputMirror* ctx, const char* recordingPath);
+void MsRdpEx_OutputMirror_SetSessionId(MsRdpEx_OutputMirror* ctx, const char* sessionId);
 
 bool MsRdpEx_OutputMirror_GetShadowBitmap(MsRdpEx_OutputMirror* ctx,
 	HDC* phDC, HBITMAP* phBitmap, uint8_t** pBitmapData,

--- a/include/MsRdpEx/RdpSettings.h
+++ b/include/MsRdpEx/RdpSettings.h
@@ -39,6 +39,7 @@ public:
     HRESULT __stdcall SetTargetPassword(const char* password);
     HRESULT __stdcall SetGatewayPassword(const char* password);
     HRESULT __stdcall SetKdcProxyUrl(const char* kdcProxyUrl);
+    HRESULT __stdcall SetRecordingPath(const char* recordingPath);
     HRESULT __stdcall AttachRdpClient(IMsTscAx* pMsTscAx);
     HRESULT __stdcall ApplyRdpFile(void* rdpFilePtr);
     HRESULT __stdcall LoadRdpFile(const char* rdpFileName);
@@ -46,6 +47,7 @@ public:
     HRESULT __stdcall GetCorePropsRawPtr(LPVOID* ppCorePropsRaw);
     HRESULT __stdcall PrepareSspiSessionIdHack();
     HRESULT __stdcall PrepareMouseJiggler();
+    HRESULT __stdcall PrepareVideoRecorder();
     HRESULT __stdcall PrepareExtraSystemMenu();
     char* __stdcall GetKdcProxyUrl();
     char* __stdcall GetKdcProxyName();
@@ -54,10 +56,17 @@ public:
     uint32_t GetMouseJigglerMethod();
     bool GetKeyboardHookToggleShortcutEnabled();
     const char* GetKeyboardHookToggleShortcutKey();
+    const char* GetSessionId();
+    bool GetOutputMirrorEnabled();
+    bool GetVideoRecordingEnabled();
+    uint32_t GetVideoRecordingQuality();
+    char* GetRecordingPath();
+    bool GetDumpBitmapUpdates();
     bool GetExtraSystemMenuEnabled();
 
 private:
     GUID m_sessionId;
+    char m_sessionIdStr[MSRDPEX_GUID_STRING_SIZE];
     ULONG m_refCount = 0;
     IUnknown* m_pUnknown = NULL;
     IMsTscAx* m_pMsTscAx = NULL;
@@ -72,6 +81,11 @@ private:
     bool m_MouseJigglerEnabled = false;
     uint32_t m_MouseJigglerInterval = 60;
     uint32_t m_MouseJigglerMethod = 0;
+    bool m_OutputMirrorEnabled = false;
+    bool m_VideoRecordingEnabled = false;
+    uint32_t m_VideoRecordingQuality = 5;
+    char* m_RecordingPath = NULL;
+    bool m_DumpBitmapUpdates = false;
     bool m_ExtraSystemMenuEnabled = true;
     bool m_KeyboardHookToggleShortcutEnabled = false;
     char m_KeyboardHookToggleShortcutKey[32];

--- a/include/MsRdpEx/VideoRecorder.h
+++ b/include/MsRdpEx/VideoRecorder.h
@@ -22,6 +22,11 @@ typedef void (CDECL* fnRecorder_Timeout)(XmfRecorder* ctx);
 typedef uint32_t (CDECL* fnRecorder_GetTimeout)(XmfRecorder* ctx);
 typedef void (CDECL* fnRecorder_Free)(XmfRecorder* ctx);
 
+typedef void XmfWebMMuxer;
+typedef XmfWebMMuxer* (CDECL* fnXmfWebMMuxer_New)();
+typedef int (CDECL* fnXmfWebMMuxer_Remux)(XmfWebMMuxer* ctx, const char* inputFile, const char* outputFile);
+typedef void (CDECL* fnXmfWebMMuxer_Free)(XmfWebMMuxer* ctx);
+
 struct _MsRdpEx_VideoRecorder
 {
     HMODULE hModule;
@@ -37,6 +42,12 @@ struct _MsRdpEx_VideoRecorder
     fnRecorder_Timeout Recorder_Timeout;
     fnRecorder_GetTimeout Recorder_GetTimeout;
     fnRecorder_Free Recorder_Free;
+
+    fnXmfWebMMuxer_New XmfWebMMuxer_New;
+    fnXmfWebMMuxer_Remux XmfWebMMuxer_Remux;
+    fnXmfWebMMuxer_Free XmfWebMMuxer_Free;
+
+    char filename[MSRDPEX_MAX_PATH];
 };
 typedef struct _MsRdpEx_VideoRecorder MsRdpEx_VideoRecorder;
 
@@ -55,6 +66,8 @@ void MsRdpEx_VideoRecorder_UpdateFrame(MsRdpEx_VideoRecorder* ctx,
 
 void MsRdpEx_VideoRecorder_Timeout(MsRdpEx_VideoRecorder* ctx);
 uint32_t MsRdpEx_VideoRecorder_GetTimeout(MsRdpEx_VideoRecorder* ctx);
+
+bool MsRdpEx_VideoRecorder_Remux(MsRdpEx_VideoRecorder* ctx, const char* filename);
 
 MsRdpEx_VideoRecorder* MsRdpEx_VideoRecorder_New();
 void MsRdpEx_VideoRecorder_Free(MsRdpEx_VideoRecorder* ctx);


### PR DESCRIPTION
Improve session recording capabilities with the following settings that can be set through the RDP ActiveX extended properties or .RDP file options:

- VideoRecordingEnabled: enables video recording (webm only)
- VideoRecordingQuality: a quality level value between 1 and 10
- RecordingPath: the base output path for recordings
- DumpBitmapUpdates: a basic bitmap dump feature

Video recording requires xmf.dll, the library from [Cadeau](https://github.com/Devolutions/cadeau). There's a prebuilt nuget package available, as it's difficult to build from source. MsRdpEx loads the library dynamically if present if it's in the same directory as MsRdpEx..dll, otherwise the path can be set using the MSRDPEX_XMF_DLL environment variable.

Because the webm video file is produced in *streaming* mode, it doesn't contain seeking information by default, but I've added code to remux it when finishing the recording to make the files seekable.

Video recordings are created in subdirectories matching the session id. Since video formats like webm don't handle resolution changes well, multiple videos are created in order whenever the resolution changes: recording-0.webm, recording-1.webm, etc.

When bitmap dumping is enabled, you'll get a series of frame_0000.bmp files in the output directory, with a "frame_meta.psv" pipe-separated value file containing metadata on the bitmap dumps, like timestamps, etc.