### PR TITLE
fix(recording): expand locks for OutputMirror in CaptureBlt hook

### DIFF
--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -471,6 +471,8 @@ bool WINAPI MsRdpEx_CaptureBlt(
 
     MsRdpEx_OutputMirror_GetFrameSize(outputMirror, &frameWidth, &frameHeight);
 
+    MsRdpEx_OutputMirror_Lock(outputMirror);
+
     if ((frameWidth != bitmapWidth) || (frameHeight != bitmapHeight))
     {
         MsRdpEx_OutputMirror_Uninit(outputMirror);
@@ -479,11 +481,10 @@ bool WINAPI MsRdpEx_CaptureBlt(
         MsRdpEx_OutputMirror_Init(outputMirror);
     }
 
-    MsRdpEx_OutputMirror_Lock(outputMirror);
     HDC hShadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
     BitBlt(hShadowDC, dstX, dstY, width, height, hdcSrc, srcX, srcY, SRCCOPY);
-    MsRdpEx_OutputMirror_Unlock(outputMirror);
     MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+    MsRdpEx_OutputMirror_Unlock(outputMirror);
 
     captured = true;
 end:


### PR DESCRIPTION
It's necessary to expand the lock around `OutputMirror` re-initialization, otherwise we _regularly_ crash when resizing the client.