### PR TITLE
[DVLS-14562] Add frame rate control to video recording

### DIFF
--- a/PowerShell/packages.lock.json
+++ b/PowerShell/packages.lock.json
@@ -8,25 +8,11 @@
         "resolved": "2022.1.24",
         "contentHash": "zUhuNeCJOlgO0iho9JbyFeoagGE9belZKKKSJakwtvewTCk+G1L3T3bTr3J/xLO1tE3kSBlakJQD8ol11+ExKQ=="
       },
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "PowerShellStandard.Library": {
         "type": "Direct",
         "requested": "[5.1.0, )",
         "resolved": "5.1.0",
         "contentHash": "iYaRvQsM1fow9h3uEmio+2m2VXfulgI16AYHaTZ8Sf7erGe27Qc8w/h6QL5UPuwv1aXR40QfzMEwcCeiYJp2cw=="
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       }
     }
   }

--- a/PowerShell/packages.lock.json
+++ b/PowerShell/packages.lock.json
@@ -8,11 +8,25 @@
         "resolved": "2022.1.24",
         "contentHash": "zUhuNeCJOlgO0iho9JbyFeoagGE9belZKKKSJakwtvewTCk+G1L3T3bTr3J/xLO1tE3kSBlakJQD8ol11+ExKQ=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "PowerShellStandard.Library": {
         "type": "Direct",
         "requested": "[5.1.0, )",
         "resolved": "5.1.0",
         "contentHash": "iYaRvQsM1fow9h3uEmio+2m2VXfulgI16AYHaTZ8Sf7erGe27Qc8w/h6QL5UPuwv1aXR40QfzMEwcCeiYJp2cw=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       }
     }
   }

--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -431,6 +431,9 @@ bool WINAPI MsRdpEx_CaptureBlt(
     bool outputMirrorEnabled = false;
     bool videoRecordingEnabled = false;
     uint32_t videoRecordingQuality = 5;
+    uint32_t videoRecordingFrameRate = 0;
+    uint32_t videoRecordingWidth = 0;
+    uint32_t videoRecordingHeight = 0;
     bool dumpBitmapUpdates = false;
     IMsRdpExInstance* instance = NULL;
     MsRdpEx_OutputMirror* outputMirror = NULL;
@@ -457,6 +460,9 @@ bool WINAPI MsRdpEx_CaptureBlt(
     outputMirrorEnabled = pExtendedSettings->GetOutputMirrorEnabled();
     videoRecordingEnabled = pExtendedSettings->GetVideoRecordingEnabled();
     videoRecordingQuality = pExtendedSettings->GetVideoRecordingQuality();
+    videoRecordingFrameRate = pExtendedSettings->GetVideoRecordingFrameRate();
+    videoRecordingWidth = pExtendedSettings->GetVideoRecordingWidth();
+    videoRecordingHeight = pExtendedSettings->GetVideoRecordingHeight();
     dumpBitmapUpdates = pExtendedSettings->GetDumpBitmapUpdates();
 
     if (!outputMirrorEnabled)
@@ -476,6 +482,8 @@ bool WINAPI MsRdpEx_CaptureBlt(
         MsRdpEx_OutputMirror_SetDumpBitmapUpdates(outputMirror, dumpBitmapUpdates);
         MsRdpEx_OutputMirror_SetVideoRecordingEnabled(outputMirror, videoRecordingEnabled);
         MsRdpEx_OutputMirror_SetVideoQualityLevel(outputMirror, videoRecordingQuality);
+        MsRdpEx_OutputMirror_SetVideoFrameRate(outputMirror, videoRecordingFrameRate);
+        MsRdpEx_OutputMirror_SetRecordingResolution(outputMirror, videoRecordingWidth, videoRecordingHeight);
 
         char* recordingPath = pExtendedSettings->GetRecordingPath();
         if (recordingPath) {

--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -432,8 +432,6 @@ bool WINAPI MsRdpEx_CaptureBlt(
     bool videoRecordingEnabled = false;
     uint32_t videoRecordingQuality = 5;
     uint32_t videoRecordingFrameRate = 0;
-    uint32_t videoRecordingWidth = 0;
-    uint32_t videoRecordingHeight = 0;
     bool dumpBitmapUpdates = false;
     IMsRdpExInstance* instance = NULL;
     MsRdpEx_OutputMirror* outputMirror = NULL;
@@ -461,8 +459,6 @@ bool WINAPI MsRdpEx_CaptureBlt(
     videoRecordingEnabled = pExtendedSettings->GetVideoRecordingEnabled();
     videoRecordingQuality = pExtendedSettings->GetVideoRecordingQuality();
     videoRecordingFrameRate = pExtendedSettings->GetVideoRecordingFrameRate();
-    videoRecordingWidth = pExtendedSettings->GetVideoRecordingWidth();
-    videoRecordingHeight = pExtendedSettings->GetVideoRecordingHeight();
     dumpBitmapUpdates = pExtendedSettings->GetDumpBitmapUpdates();
 
     if (!outputMirrorEnabled)
@@ -483,7 +479,6 @@ bool WINAPI MsRdpEx_CaptureBlt(
         MsRdpEx_OutputMirror_SetVideoRecordingEnabled(outputMirror, videoRecordingEnabled);
         MsRdpEx_OutputMirror_SetVideoQualityLevel(outputMirror, videoRecordingQuality);
         MsRdpEx_OutputMirror_SetVideoFrameRate(outputMirror, videoRecordingFrameRate);
-        MsRdpEx_OutputMirror_SetRecordingResolution(outputMirror, videoRecordingWidth, videoRecordingHeight);
 
         char* recordingPath = pExtendedSettings->GetRecordingPath();
         if (recordingPath) {

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -34,6 +34,20 @@ struct _MsRdpEx_OutputMirror
 	MsRdpEx_RecordingManifest* manifest;
 	FILE* frameMetadataFile;
 
+	uint32_t videoFrameRate;
+	uint32_t recordingWidth;
+	uint32_t recordingHeight;
+	uint64_t lastEncodeTime;
+
+	bool scalingEnabled;
+	HDC hScaledDC;
+	HBITMAP hScaledBitmap;
+	HGDIOBJ hScaledObject;
+	uint8_t* scaledBitmapData;
+	uint32_t scaledBitmapWidth;
+	uint32_t scaledBitmapHeight;
+	uint32_t scaledBitmapStep;
+
     CRITICAL_SECTION lock;
 };
 
@@ -83,9 +97,36 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx)
 	captureTime = GetTickCount64() - ctx->captureBaseTime;
 
 	if (ctx->videoRecordingEnabled && ctx->videoRecorder) {
-		MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->bitmapData,
-			0, 0, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitmapStep);
-		MsRdpEx_VideoRecorder_Timeout(ctx->videoRecorder);
+		// The native path is paint-driven (one DumpFrame per RDP update), so cap the encode cadence to the
+		// configured frame rate here -- the encoder itself does not drop frames. Mirrors the internal timer path.
+		bool encodeThisFrame = true;
+
+		if (ctx->videoFrameRate > 0) {
+			uint64_t now = GetTickCount64();
+			uint32_t intervalMs = 1000 / ctx->videoFrameRate;
+
+			if ((ctx->lastEncodeTime != 0) && ((now - ctx->lastEncodeTime) < intervalMs)) {
+				encodeThisFrame = false;
+			}
+			else {
+				ctx->lastEncodeTime = now;
+			}
+		}
+
+		if (encodeThisFrame) {
+			if (ctx->scalingEnabled) {
+				StretchBlt(ctx->hScaledDC, 0, 0, ctx->scaledBitmapWidth, ctx->scaledBitmapHeight,
+					ctx->hShadowDC, 0, 0, ctx->bitmapWidth, ctx->bitmapHeight, SRCCOPY);
+				GdiFlush();
+				MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->scaledBitmapData,
+					0, 0, ctx->scaledBitmapWidth, ctx->scaledBitmapHeight, ctx->scaledBitmapStep);
+			}
+			else {
+				MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->bitmapData,
+					0, 0, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitmapStep);
+			}
+			MsRdpEx_VideoRecorder_Timeout(ctx->videoRecorder);
+		}
 	}
 
 	if (ctx->dumpBitmapUpdates) {
@@ -119,6 +160,17 @@ void MsRdpEx_OutputMirror_SetVideoRecordingEnabled(MsRdpEx_OutputMirror* ctx, bo
 void MsRdpEx_OutputMirror_SetVideoQualityLevel(MsRdpEx_OutputMirror* ctx, uint32_t videoQualityLevel)
 {
 	ctx->videoQualityLevel = videoQualityLevel;
+}
+
+void MsRdpEx_OutputMirror_SetVideoFrameRate(MsRdpEx_OutputMirror* ctx, uint32_t videoFrameRate)
+{
+	ctx->videoFrameRate = videoFrameRate;
+}
+
+void MsRdpEx_OutputMirror_SetRecordingResolution(MsRdpEx_OutputMirror* ctx, uint32_t recordingWidth, uint32_t recordingHeight)
+{
+	ctx->recordingWidth = recordingWidth;
+	ctx->recordingHeight = recordingHeight;
 }
 
 void MsRdpEx_OutputMirror_SetRecordingPath(MsRdpEx_OutputMirror* ctx, const char* recordingPath)
@@ -202,6 +254,28 @@ bool MsRdpEx_OutputMirror_Init(MsRdpEx_OutputMirror* ctx)
 		sprintf_s(ctx->outputPath, MSRDPEX_MAX_PATH, "%s\\%s", ctx->recordingPath, ctx->sessionId);
 		MsRdpEx_MakePath(ctx->outputPath, NULL);
 
+		uint32_t encodeWidth = ctx->bitmapWidth;
+		uint32_t encodeHeight = ctx->bitmapHeight;
+
+		// Downscale the captured frame to the requested recording resolution before encoding. The xmf encoder
+		// does not scale, so without this it records at the native desktop size regardless of the configured value.
+		ctx->scalingEnabled = (ctx->recordingWidth > 0) && (ctx->recordingHeight > 0)
+			&& ((ctx->recordingWidth != ctx->bitmapWidth) || (ctx->recordingHeight != ctx->bitmapHeight));
+
+		if (ctx->scalingEnabled) {
+			encodeWidth = ctx->recordingWidth;
+			encodeHeight = ctx->recordingHeight;
+			ctx->scaledBitmapWidth = encodeWidth;
+			ctx->scaledBitmapHeight = encodeHeight;
+			ctx->scaledBitmapStep = encodeWidth * 4;
+			ctx->hScaledDC = CreateCompatibleDC(ctx->hSourceDC);
+			ctx->hScaledBitmap = MsRdpEx_CreateDIBSection(ctx->hSourceDC,
+				encodeWidth, encodeHeight, ctx->bitsPerPixel, &ctx->scaledBitmapData);
+			ctx->hScaledObject = SelectObject(ctx->hScaledDC, ctx->hScaledBitmap);
+			SetStretchBltMode(ctx->hScaledDC, HALFTONE);
+			SetBrushOrgEx(ctx->hScaledDC, 0, 0, NULL);
+		}
+
 		ctx->videoRecorder = MsRdpEx_VideoRecorder_New();
 
 		if (ctx->videoRecorder) {
@@ -210,9 +284,13 @@ bool MsRdpEx_OutputMirror_Init(MsRdpEx_OutputMirror* ctx)
 			MsRdpEx_RecordingManifest_FinalizeFile(ctx->manifest, 0);
 			MsRdpEx_RecordingManifest_AddFile(ctx->manifest, MsRdpEx_FileBase(filename), startTime, 0);
 			ctx->videoRecordingCount++;
-			MsRdpEx_VideoRecorder_SetFrameSize(ctx->videoRecorder, ctx->bitmapWidth, ctx->bitmapHeight);
+			MsRdpEx_VideoRecorder_SetFrameSize(ctx->videoRecorder, encodeWidth, encodeHeight);
 			MsRdpEx_VideoRecorder_SetFileName(ctx->videoRecorder, filename);
 			MsRdpEx_VideoRecorder_SetVideoQuality(ctx->videoRecorder, ctx->videoQualityLevel);
+
+			if (ctx->videoFrameRate > 0) {
+				MsRdpEx_VideoRecorder_SetFrameRate(ctx->videoRecorder, ctx->videoFrameRate);
+			}
 
 			if (!MsRdpEx_StringIsNullOrEmpty(ctx->recordingPipeName)) {
 				MsRdpEx_VideoRecorder_SetPipeName(ctx->videoRecorder, ctx->recordingPipeName);
@@ -247,6 +325,18 @@ bool MsRdpEx_OutputMirror_Uninit(MsRdpEx_OutputMirror* ctx)
 	{
 		DeleteDC(ctx->hShadowDC);
 		ctx->hShadowDC = NULL;
+	}
+
+	if (ctx->hScaledDC)
+	{
+		SelectObject(ctx->hScaledDC, ctx->hScaledObject);
+		DeleteObject(ctx->hScaledBitmap);
+		DeleteDC(ctx->hScaledDC);
+		ctx->hScaledObject = NULL;
+		ctx->hScaledBitmap = NULL;
+		ctx->hScaledDC = NULL;
+		ctx->scaledBitmapData = NULL;
+		ctx->scalingEnabled = false;
 	}
 
 	if (ctx->videoRecorder) {

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -87,9 +87,7 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx)
 	captureTime = GetTickCount64() - ctx->captureBaseTime;
 
 	if (ctx->videoRecordingEnabled && ctx->videoRecorder) {
-		// [DVLS-14562] Submit every captured paint and let cadeau cap the encode rate to the configured
-		// frame rate (ms_per_frame). No manual throttle and no per-paint Timeout -- Timeout force-encodes
-		// and would bypass cadeau's cap. The frame rate is conveyed once via SetFrameRate in Init.
+		// Submit every paint; cadeau caps the encode rate. A per-paint Timeout would force-encode and bypass that cap.
 		MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->bitmapData,
 			0, 0, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitmapStep);
 	}

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -7,8 +7,6 @@
 #include <MsRdpEx/RecordingManifest.h>
 #include <MsRdpEx/OutputMirror.h>
 
-#define MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE 60
-
 struct _MsRdpEx_OutputMirror
 {
 	uint8_t* bitmapData;
@@ -127,10 +125,6 @@ void MsRdpEx_OutputMirror_SetVideoQualityLevel(MsRdpEx_OutputMirror* ctx, uint32
 
 void MsRdpEx_OutputMirror_SetVideoFrameRate(MsRdpEx_OutputMirror* ctx, uint32_t videoFrameRate)
 {
-	if (videoFrameRate > MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE) {
-		videoFrameRate = MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE;
-	}
-
 	ctx->videoFrameRate = videoFrameRate;
 }
 

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -7,6 +7,8 @@
 #include <MsRdpEx/RecordingManifest.h>
 #include <MsRdpEx/OutputMirror.h>
 
+#define MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE 60
+
 struct _MsRdpEx_OutputMirror
 {
 	uint8_t* bitmapData;
@@ -35,18 +37,7 @@ struct _MsRdpEx_OutputMirror
 	FILE* frameMetadataFile;
 
 	uint32_t videoFrameRate;
-	uint32_t recordingWidth;
-	uint32_t recordingHeight;
 	uint64_t lastEncodeTime;
-
-	bool scalingEnabled;
-	HDC hScaledDC;
-	HBITMAP hScaledBitmap;
-	HGDIOBJ hScaledObject;
-	uint8_t* scaledBitmapData;
-	uint32_t scaledBitmapWidth;
-	uint32_t scaledBitmapHeight;
-	uint32_t scaledBitmapStep;
 
     CRITICAL_SECTION lock;
 };
@@ -114,17 +105,8 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx)
 		}
 
 		if (encodeThisFrame) {
-			if (ctx->scalingEnabled) {
-				StretchBlt(ctx->hScaledDC, 0, 0, ctx->scaledBitmapWidth, ctx->scaledBitmapHeight,
-					ctx->hShadowDC, 0, 0, ctx->bitmapWidth, ctx->bitmapHeight, SRCCOPY);
-				GdiFlush();
-				MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->scaledBitmapData,
-					0, 0, ctx->scaledBitmapWidth, ctx->scaledBitmapHeight, ctx->scaledBitmapStep);
-			}
-			else {
-				MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->bitmapData,
-					0, 0, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitmapStep);
-			}
+			MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->bitmapData,
+				0, 0, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitmapStep);
 			MsRdpEx_VideoRecorder_Timeout(ctx->videoRecorder);
 		}
 	}
@@ -164,13 +146,11 @@ void MsRdpEx_OutputMirror_SetVideoQualityLevel(MsRdpEx_OutputMirror* ctx, uint32
 
 void MsRdpEx_OutputMirror_SetVideoFrameRate(MsRdpEx_OutputMirror* ctx, uint32_t videoFrameRate)
 {
-	ctx->videoFrameRate = videoFrameRate;
-}
+	if (videoFrameRate > MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE) {
+		videoFrameRate = MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE;
+	}
 
-void MsRdpEx_OutputMirror_SetRecordingResolution(MsRdpEx_OutputMirror* ctx, uint32_t recordingWidth, uint32_t recordingHeight)
-{
-	ctx->recordingWidth = recordingWidth;
-	ctx->recordingHeight = recordingHeight;
+	ctx->videoFrameRate = videoFrameRate;
 }
 
 void MsRdpEx_OutputMirror_SetRecordingPath(MsRdpEx_OutputMirror* ctx, const char* recordingPath)
@@ -254,28 +234,6 @@ bool MsRdpEx_OutputMirror_Init(MsRdpEx_OutputMirror* ctx)
 		sprintf_s(ctx->outputPath, MSRDPEX_MAX_PATH, "%s\\%s", ctx->recordingPath, ctx->sessionId);
 		MsRdpEx_MakePath(ctx->outputPath, NULL);
 
-		uint32_t encodeWidth = ctx->bitmapWidth;
-		uint32_t encodeHeight = ctx->bitmapHeight;
-
-		// Downscale the captured frame to the requested recording resolution before encoding. The xmf encoder
-		// does not scale, so without this it records at the native desktop size regardless of the configured value.
-		ctx->scalingEnabled = (ctx->recordingWidth > 0) && (ctx->recordingHeight > 0)
-			&& ((ctx->recordingWidth != ctx->bitmapWidth) || (ctx->recordingHeight != ctx->bitmapHeight));
-
-		if (ctx->scalingEnabled) {
-			encodeWidth = ctx->recordingWidth;
-			encodeHeight = ctx->recordingHeight;
-			ctx->scaledBitmapWidth = encodeWidth;
-			ctx->scaledBitmapHeight = encodeHeight;
-			ctx->scaledBitmapStep = encodeWidth * 4;
-			ctx->hScaledDC = CreateCompatibleDC(ctx->hSourceDC);
-			ctx->hScaledBitmap = MsRdpEx_CreateDIBSection(ctx->hSourceDC,
-				encodeWidth, encodeHeight, ctx->bitsPerPixel, &ctx->scaledBitmapData);
-			ctx->hScaledObject = SelectObject(ctx->hScaledDC, ctx->hScaledBitmap);
-			SetStretchBltMode(ctx->hScaledDC, HALFTONE);
-			SetBrushOrgEx(ctx->hScaledDC, 0, 0, NULL);
-		}
-
 		ctx->videoRecorder = MsRdpEx_VideoRecorder_New();
 
 		if (ctx->videoRecorder) {
@@ -284,7 +242,7 @@ bool MsRdpEx_OutputMirror_Init(MsRdpEx_OutputMirror* ctx)
 			MsRdpEx_RecordingManifest_FinalizeFile(ctx->manifest, 0);
 			MsRdpEx_RecordingManifest_AddFile(ctx->manifest, MsRdpEx_FileBase(filename), startTime, 0);
 			ctx->videoRecordingCount++;
-			MsRdpEx_VideoRecorder_SetFrameSize(ctx->videoRecorder, encodeWidth, encodeHeight);
+			MsRdpEx_VideoRecorder_SetFrameSize(ctx->videoRecorder, ctx->bitmapWidth, ctx->bitmapHeight);
 			MsRdpEx_VideoRecorder_SetFileName(ctx->videoRecorder, filename);
 			MsRdpEx_VideoRecorder_SetVideoQuality(ctx->videoRecorder, ctx->videoQualityLevel);
 
@@ -325,18 +283,6 @@ bool MsRdpEx_OutputMirror_Uninit(MsRdpEx_OutputMirror* ctx)
 	{
 		DeleteDC(ctx->hShadowDC);
 		ctx->hShadowDC = NULL;
-	}
-
-	if (ctx->hScaledDC)
-	{
-		SelectObject(ctx->hScaledDC, ctx->hScaledObject);
-		DeleteObject(ctx->hScaledBitmap);
-		DeleteDC(ctx->hScaledDC);
-		ctx->hScaledObject = NULL;
-		ctx->hScaledBitmap = NULL;
-		ctx->hScaledDC = NULL;
-		ctx->scaledBitmapData = NULL;
-		ctx->scalingEnabled = false;
 	}
 
 	if (ctx->videoRecorder) {

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -37,7 +37,6 @@ struct _MsRdpEx_OutputMirror
 	FILE* frameMetadataFile;
 
 	uint32_t videoFrameRate;
-	uint64_t lastEncodeTime;
 
     CRITICAL_SECTION lock;
 };
@@ -88,27 +87,11 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx)
 	captureTime = GetTickCount64() - ctx->captureBaseTime;
 
 	if (ctx->videoRecordingEnabled && ctx->videoRecorder) {
-		// The native path is paint-driven (one DumpFrame per RDP update), so cap the encode cadence to the
-		// configured frame rate here -- the encoder itself does not drop frames. Mirrors the internal timer path.
-		bool encodeThisFrame = true;
-
-		if (ctx->videoFrameRate > 0) {
-			uint64_t now = GetTickCount64();
-			uint32_t intervalMs = 1000 / ctx->videoFrameRate;
-
-			if ((ctx->lastEncodeTime != 0) && ((now - ctx->lastEncodeTime) < intervalMs)) {
-				encodeThisFrame = false;
-			}
-			else {
-				ctx->lastEncodeTime = now;
-			}
-		}
-
-		if (encodeThisFrame) {
-			MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->bitmapData,
-				0, 0, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitmapStep);
-			MsRdpEx_VideoRecorder_Timeout(ctx->videoRecorder);
-		}
+		// [DVLS-14562] Submit every captured paint and let cadeau cap the encode rate to the configured
+		// frame rate (ms_per_frame). No manual throttle and no per-paint Timeout -- Timeout force-encodes
+		// and would bypass cadeau's cap. The frame rate is conveyed once via SetFrameRate in Init.
+		MsRdpEx_VideoRecorder_UpdateFrame(ctx->videoRecorder, ctx->bitmapData,
+			0, 0, ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitmapStep);
 	}
 
 	if (ctx->dumpBitmapUpdates) {

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -19,6 +19,19 @@ extern "C" const GUID IID_ITSPropertySet;
 extern MsRdpEx_mstscax g_mstscax;
 extern MsRdpEx_rdclientax g_rdclientax;
 
+#define MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE 60
+
+static uint32_t MsRdpEx_VariantToNonNegativeUInt32(VARIANT* pValue)
+{
+    if (pValue->vt == VT_UI4)
+        return pValue->uintVal;
+
+    if (pValue->vt == VT_I4)
+        return pValue->intVal > 0 ? (uint32_t)pValue->intVal : 0;
+
+    return 0;
+}
+
 static bool g_TSPropertySet_Hooked = false;
 
 static ITSPropertySet_SetBoolProperty Real_ITSPropertySet_SetBoolProperty = NULL;
@@ -831,23 +844,11 @@ HRESULT __stdcall CMsRdpExtendedSettings::put_Property(BSTR bstrPropertyName, VA
         if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
             goto end;
 
-        m_VideoRecordingFrameRate = (uint32_t)pValue->uintVal;
-        hr = S_OK;
-    }
-    else if (MsRdpEx_StringEquals(propName, "VideoRecordingWidth"))
-    {
-        if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
-            goto end;
+        m_VideoRecordingFrameRate = MsRdpEx_VariantToNonNegativeUInt32(pValue);
 
-        m_VideoRecordingWidth = (uint32_t)pValue->uintVal;
-        hr = S_OK;
-    }
-    else if (MsRdpEx_StringEquals(propName, "VideoRecordingHeight"))
-    {
-        if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
-            goto end;
+        if (m_VideoRecordingFrameRate > MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE)
+            m_VideoRecordingFrameRate = MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE;
 
-        m_VideoRecordingHeight = (uint32_t)pValue->uintVal;
         hr = S_OK;
     }
     else if (MsRdpEx_StringEquals(propName, "RecordingPath"))
@@ -998,16 +999,6 @@ HRESULT __stdcall CMsRdpExtendedSettings::get_Property(BSTR bstrPropertyName, VA
     else if (MsRdpEx_StringEquals(propName, "VideoRecordingFrameRate")) {
         pValue->vt = VT_I4;
         pValue->intVal = (INT)m_VideoRecordingFrameRate;
-        hr = S_OK;
-    }
-    else if (MsRdpEx_StringEquals(propName, "VideoRecordingWidth")) {
-        pValue->vt = VT_I4;
-        pValue->intVal = (INT)m_VideoRecordingWidth;
-        hr = S_OK;
-    }
-    else if (MsRdpEx_StringEquals(propName, "VideoRecordingHeight")) {
-        pValue->vt = VT_I4;
-        pValue->intVal = (INT)m_VideoRecordingHeight;
         hr = S_OK;
     }
     else if (MsRdpEx_StringEquals(propName, "RecordingPath")) {
@@ -1429,18 +1420,6 @@ HRESULT CMsRdpExtendedSettings::ApplyRdpFile(void* rdpFilePtr)
                 pMsRdpExtendedSettings->put_Property(propName, &value);
             }
         }
-        else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "VideoRecordingWidth")) {
-            if (MsRdpEx_RdpFileEntry_GetIntValue(entry, &value)) {
-                bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
-                pMsRdpExtendedSettings->put_Property(propName, &value);
-            }
-        }
-        else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "VideoRecordingHeight")) {
-            if (MsRdpEx_RdpFileEntry_GetIntValue(entry, &value)) {
-                bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
-                pMsRdpExtendedSettings->put_Property(propName, &value);
-            }
-        }
         else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 's', "RecordingPath")) {
             bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
             bstr_t propValue = _com_util::ConvertStringToBSTR(entry->value);
@@ -1695,16 +1674,6 @@ uint32_t CMsRdpExtendedSettings::GetVideoRecordingQuality()
 uint32_t CMsRdpExtendedSettings::GetVideoRecordingFrameRate()
 {
     return m_VideoRecordingFrameRate;
-}
-
-uint32_t CMsRdpExtendedSettings::GetVideoRecordingWidth()
-{
-    return m_VideoRecordingWidth;
-}
-
-uint32_t CMsRdpExtendedSettings::GetVideoRecordingHeight()
-{
-    return m_VideoRecordingHeight;
 }
 
 char* CMsRdpExtendedSettings::GetRecordingPath()

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -826,6 +826,30 @@ HRESULT __stdcall CMsRdpExtendedSettings::put_Property(BSTR bstrPropertyName, VA
 
         hr = S_OK;
     }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingFrameRate"))
+    {
+        if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
+            goto end;
+
+        m_VideoRecordingFrameRate = (uint32_t)pValue->uintVal;
+        hr = S_OK;
+    }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingWidth"))
+    {
+        if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
+            goto end;
+
+        m_VideoRecordingWidth = (uint32_t)pValue->uintVal;
+        hr = S_OK;
+    }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingHeight"))
+    {
+        if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
+            goto end;
+
+        m_VideoRecordingHeight = (uint32_t)pValue->uintVal;
+        hr = S_OK;
+    }
     else if (MsRdpEx_StringEquals(propName, "RecordingPath"))
     {
         if (pValue->vt != VT_BSTR)
@@ -969,6 +993,21 @@ HRESULT __stdcall CMsRdpExtendedSettings::get_Property(BSTR bstrPropertyName, VA
     else if (MsRdpEx_StringEquals(propName, "VideoRecordingQuality")) {
         pValue->vt = VT_I4;
         pValue->intVal = (INT)m_VideoRecordingQuality;
+        hr = S_OK;
+    }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingFrameRate")) {
+        pValue->vt = VT_I4;
+        pValue->intVal = (INT)m_VideoRecordingFrameRate;
+        hr = S_OK;
+    }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingWidth")) {
+        pValue->vt = VT_I4;
+        pValue->intVal = (INT)m_VideoRecordingWidth;
+        hr = S_OK;
+    }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingHeight")) {
+        pValue->vt = VT_I4;
+        pValue->intVal = (INT)m_VideoRecordingHeight;
         hr = S_OK;
     }
     else if (MsRdpEx_StringEquals(propName, "RecordingPath")) {
@@ -1384,6 +1423,24 @@ HRESULT CMsRdpExtendedSettings::ApplyRdpFile(void* rdpFilePtr)
                 pMsRdpExtendedSettings->put_Property(propName, &value);
             }
         }
+        else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "VideoRecordingFrameRate")) {
+            if (MsRdpEx_RdpFileEntry_GetIntValue(entry, &value)) {
+                bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
+                pMsRdpExtendedSettings->put_Property(propName, &value);
+            }
+        }
+        else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "VideoRecordingWidth")) {
+            if (MsRdpEx_RdpFileEntry_GetIntValue(entry, &value)) {
+                bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
+                pMsRdpExtendedSettings->put_Property(propName, &value);
+            }
+        }
+        else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "VideoRecordingHeight")) {
+            if (MsRdpEx_RdpFileEntry_GetIntValue(entry, &value)) {
+                bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
+                pMsRdpExtendedSettings->put_Property(propName, &value);
+            }
+        }
         else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 's', "RecordingPath")) {
             bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
             bstr_t propValue = _com_util::ConvertStringToBSTR(entry->value);
@@ -1633,6 +1690,21 @@ bool CMsRdpExtendedSettings::GetVideoRecordingEnabled()
 uint32_t CMsRdpExtendedSettings::GetVideoRecordingQuality()
 {
     return m_VideoRecordingQuality;
+}
+
+uint32_t CMsRdpExtendedSettings::GetVideoRecordingFrameRate()
+{
+    return m_VideoRecordingFrameRate;
+}
+
+uint32_t CMsRdpExtendedSettings::GetVideoRecordingWidth()
+{
+    return m_VideoRecordingWidth;
+}
+
+uint32_t CMsRdpExtendedSettings::GetVideoRecordingHeight()
+{
+    return m_VideoRecordingHeight;
 }
 
 char* CMsRdpExtendedSettings::GetRecordingPath()

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -19,7 +19,7 @@ extern "C" const GUID IID_ITSPropertySet;
 extern MsRdpEx_mstscax g_mstscax;
 extern MsRdpEx_rdclientax g_rdclientax;
 
-#define MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE 60
+#define MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE 30
 
 static bool g_TSPropertySet_Hooked = false;
 
@@ -833,7 +833,10 @@ HRESULT __stdcall CMsRdpExtendedSettings::put_Property(BSTR bstrPropertyName, VA
         if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
             goto end;
 
-        m_VideoRecordingFrameRate = (uint32_t)pValue->uintVal;
+        if (pValue->vt == VT_I4)
+            m_VideoRecordingFrameRate = (pValue->intVal > 0) ? (uint32_t)pValue->intVal : 0;
+        else
+            m_VideoRecordingFrameRate = pValue->uintVal;
 
         if (m_VideoRecordingFrameRate > MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE)
             m_VideoRecordingFrameRate = MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE;

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -21,17 +21,6 @@ extern MsRdpEx_rdclientax g_rdclientax;
 
 #define MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE 60
 
-static uint32_t MsRdpEx_VariantToNonNegativeUInt32(VARIANT* pValue)
-{
-    if (pValue->vt == VT_UI4)
-        return pValue->uintVal;
-
-    if (pValue->vt == VT_I4)
-        return pValue->intVal > 0 ? (uint32_t)pValue->intVal : 0;
-
-    return 0;
-}
-
 static bool g_TSPropertySet_Hooked = false;
 
 static ITSPropertySet_SetBoolProperty Real_ITSPropertySet_SetBoolProperty = NULL;
@@ -844,7 +833,7 @@ HRESULT __stdcall CMsRdpExtendedSettings::put_Property(BSTR bstrPropertyName, VA
         if ((pValue->vt != VT_UI4) && (pValue->vt != VT_I4))
             goto end;
 
-        m_VideoRecordingFrameRate = MsRdpEx_VariantToNonNegativeUInt32(pValue);
+        m_VideoRecordingFrameRate = (uint32_t)pValue->uintVal;
 
         if (m_VideoRecordingFrameRate > MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE)
             m_VideoRecordingFrameRate = MSRDPEX_VIDEO_RECORDING_MAX_FRAME_RATE;

--- a/include/MsRdpEx/OutputMirror.h
+++ b/include/MsRdpEx/OutputMirror.h
@@ -23,7 +23,6 @@ void MsRdpEx_OutputMirror_SetDumpBitmapUpdates(MsRdpEx_OutputMirror* ctx, bool d
 void MsRdpEx_OutputMirror_SetVideoRecordingEnabled(MsRdpEx_OutputMirror* ctx, bool videoRecordingEnabled);
 void MsRdpEx_OutputMirror_SetVideoQualityLevel(MsRdpEx_OutputMirror* ctx, uint32_t videoQualityLevel);
 void MsRdpEx_OutputMirror_SetVideoFrameRate(MsRdpEx_OutputMirror* ctx, uint32_t videoFrameRate);
-void MsRdpEx_OutputMirror_SetRecordingResolution(MsRdpEx_OutputMirror* ctx, uint32_t recordingWidth, uint32_t recordingHeight);
 void MsRdpEx_OutputMirror_SetRecordingPath(MsRdpEx_OutputMirror* ctx, const char* recordingPath);
 void MsRdpEx_OutputMirror_SetRecordingPipeName(MsRdpEx_OutputMirror* ctx, const char* recordingPipeName);
 void MsRdpEx_OutputMirror_SetSessionId(MsRdpEx_OutputMirror* ctx, const char* sessionId);

--- a/include/MsRdpEx/OutputMirror.h
+++ b/include/MsRdpEx/OutputMirror.h
@@ -22,6 +22,8 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx);
 void MsRdpEx_OutputMirror_SetDumpBitmapUpdates(MsRdpEx_OutputMirror* ctx, bool dumpBitmapUpdates);
 void MsRdpEx_OutputMirror_SetVideoRecordingEnabled(MsRdpEx_OutputMirror* ctx, bool videoRecordingEnabled);
 void MsRdpEx_OutputMirror_SetVideoQualityLevel(MsRdpEx_OutputMirror* ctx, uint32_t videoQualityLevel);
+void MsRdpEx_OutputMirror_SetVideoFrameRate(MsRdpEx_OutputMirror* ctx, uint32_t videoFrameRate);
+void MsRdpEx_OutputMirror_SetRecordingResolution(MsRdpEx_OutputMirror* ctx, uint32_t recordingWidth, uint32_t recordingHeight);
 void MsRdpEx_OutputMirror_SetRecordingPath(MsRdpEx_OutputMirror* ctx, const char* recordingPath);
 void MsRdpEx_OutputMirror_SetRecordingPipeName(MsRdpEx_OutputMirror* ctx, const char* recordingPipeName);
 void MsRdpEx_OutputMirror_SetSessionId(MsRdpEx_OutputMirror* ctx, const char* sessionId);

--- a/include/MsRdpEx/RdpSettings.h
+++ b/include/MsRdpEx/RdpSettings.h
@@ -62,6 +62,9 @@ public:
     bool GetOutputMirrorEnabled();
     bool GetVideoRecordingEnabled();
     uint32_t GetVideoRecordingQuality();
+    uint32_t GetVideoRecordingFrameRate();
+    uint32_t GetVideoRecordingWidth();
+    uint32_t GetVideoRecordingHeight();
     char* GetRecordingPath();
     char* GetRecordingSessionId();
     char* GetRecordingPipeName();
@@ -88,6 +91,9 @@ private:
     bool m_OutputMirrorEnabled = false;
     bool m_VideoRecordingEnabled = false;
     uint32_t m_VideoRecordingQuality = 5;
+    uint32_t m_VideoRecordingFrameRate = 0;
+    uint32_t m_VideoRecordingWidth = 0;
+    uint32_t m_VideoRecordingHeight = 0;
     char* m_RecordingPath = NULL;
     char* m_RecordingSessionId = NULL;
     char* m_RecordingPipeName = NULL;

--- a/include/MsRdpEx/RdpSettings.h
+++ b/include/MsRdpEx/RdpSettings.h
@@ -63,8 +63,6 @@ public:
     bool GetVideoRecordingEnabled();
     uint32_t GetVideoRecordingQuality();
     uint32_t GetVideoRecordingFrameRate();
-    uint32_t GetVideoRecordingWidth();
-    uint32_t GetVideoRecordingHeight();
     char* GetRecordingPath();
     char* GetRecordingSessionId();
     char* GetRecordingPipeName();
@@ -92,8 +90,6 @@ private:
     bool m_VideoRecordingEnabled = false;
     uint32_t m_VideoRecordingQuality = 5;
     uint32_t m_VideoRecordingFrameRate = 0;
-    uint32_t m_VideoRecordingWidth = 0;
-    uint32_t m_VideoRecordingHeight = 0;
     char* m_RecordingPath = NULL;
     char* m_RecordingSessionId = NULL;
     char* m_RecordingPipeName = NULL;


### PR DESCRIPTION
Adds a `VideoRecordingFrameRate` extended setting (COM property + `.rdp` entry) for the native recording path. MsRdpEx now submits every captured paint and lets cadeau cap the encode rate to the configured frame rate; the per-paint `Timeout` force-encode is removed because it bypassed that cap and produced ~24fps oversized recordings. The rate is clamped to 30 to match cadeau's recorder max.

Note: when the frame rate is unset (0), cadeau falls back to its own default cap rather than the previous force-every-paint behavior. Requires the cadeau eager-first-frame fix (Devolutions/cadeau#80) so static recordings still emit a first frame promptly — the two PRs should ship together.