### PR TITLE
Composite the cursor into MS RDP recordings

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,1 +1,0 @@
-good, let's refactor accordingly

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,1 @@
+good, let's refactor accordingly

--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -517,7 +517,7 @@ bool WINAPI MsRdpEx_CaptureBlt(
     HDC hShadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
     BitBlt(hShadowDC, dstX, dstY, width, height, hdcSrc, srcX, srcY, SRCCOPY);
 
-    MsRdpEx_RdpInstance_DumpFrameWithCursor(instance);
+    instance->DumpFrameWithCursor();
     MsRdpEx_OutputMirror_Unlock(outputMirror);
 
     captured = true;
@@ -572,29 +572,6 @@ BOOL WINAPI Hook_StretchBlt(
 
 end:
     return status;
-}
-
-HCURSOR (WINAPI * Real_SetCursor)(HCURSOR hCursor) = SetCursor;
-BOOL (WINAPI * Real_GetCursorPos)(LPPOINT lpPoint) = GetCursorPos;
-
-HCURSOR WINAPI Hook_SetCursor(HCURSOR hCursor)
-{
-    HCURSOR result = Real_SetCursor(hCursor);
-    POINT point = { 0 };
-
-    if (Real_GetCursorPos(&point))
-    {
-        IMsRdpExInstance* instance =
-            MsRdpEx_InstanceManager_AcquireByScreenPoint(point);
-
-        if (instance)
-        {
-            MsRdpEx_RdpInstance_SetCursor(instance, hCursor);
-            instance->Release();
-        }
-    }
-
-    return result;
 }
 
 #define SYSMENU_RDP_RANGE_FIRST_ID               7100
@@ -991,14 +968,19 @@ LRESULT CALLBACK Hook_IHWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
             TRACKMOUSEEVENT trackMouseEvent = { sizeof(TRACKMOUSEEVENT), TME_LEAVE, hWnd, 0 };
             TrackMouseEvent(&trackMouseEvent);
             instance->SetLastMousePosition(mousePosX, mousePosY);
-            MsRdpEx_RdpInstance_SetCursor(instance, GetCursor());
-            MsRdpEx_RdpInstance_UpdateCursorPosition(instance, hWnd, mousePosX, mousePosY);
+            instance->SetCursor(GetCursor());
+            instance->UpdateCursorPosition(mousePosX, mousePosY);
         }
+    }
+    else if (uMsg == WM_SETCURSOR)
+    {
+        if (instance)
+            instance->SetCursor(GetCursor());
     }
     else if (uMsg == WM_MOUSELEAVE)
     {
         if (instance)
-            MsRdpEx_RdpInstance_HideCursor(instance);
+            instance->HideCursor();
     }
     else if (uMsg == WM_KEYDOWN)
     {
@@ -1662,7 +1644,6 @@ LONG MsRdpEx_AttachHooks()
 
     MSRDPEX_DETOUR_ATTACH(Real_BitBlt, Hook_BitBlt);
     MSRDPEX_DETOUR_ATTACH(Real_StretchBlt, Hook_StretchBlt);
-    MSRDPEX_DETOUR_ATTACH(Real_SetCursor, Hook_SetCursor);
     MSRDPEX_DETOUR_ATTACH(Real_RegisterClassExW, Hook_RegisterClassExW);
     MSRDPEX_DETOUR_ATTACH(Real_RegisterClassW, Hook_RegisterClassW);
     MSRDPEX_DETOUR_ATTACH(Real_GetClassInfoW, Hook_GetClassInfoW);
@@ -1722,7 +1703,6 @@ LONG MsRdpEx_DetachHooks()
     
     MSRDPEX_DETOUR_DETACH(Real_BitBlt, Hook_BitBlt);
     MSRDPEX_DETOUR_DETACH(Real_StretchBlt, Hook_StretchBlt);
-    MSRDPEX_DETOUR_DETACH(Real_SetCursor, Hook_SetCursor);
     MSRDPEX_DETOUR_DETACH(Real_RegisterClassExW, Hook_RegisterClassExW);
     MSRDPEX_DETOUR_DETACH(Real_RegisterClassW, Hook_RegisterClassW);
     MSRDPEX_DETOUR_DETACH(Real_GetClassInfoW, Hook_GetClassInfoW);

--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -1,5 +1,6 @@
 
 #include "MsRdpEx.h"
+#include "RdpInstanceInternal.h"
 
 #include <MsRdpEx/MsRdpEx.h>
 
@@ -442,7 +443,7 @@ bool WINAPI MsRdpEx_CaptureBlt(
     if (!hWnd)
         goto end;
 
-    instance = (IMsRdpExInstance*) MsRdpEx_InstanceManager_FindByOutputPresenterHwnd(hWnd);
+    instance = MsRdpEx_InstanceManager_AcquireByOutputPresenterHwnd(hWnd);
 
     if (!instance)
         goto end;
@@ -515,11 +516,15 @@ bool WINAPI MsRdpEx_CaptureBlt(
 
     HDC hShadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
     BitBlt(hShadowDC, dstX, dstY, width, height, hdcSrc, srcX, srcY, SRCCOPY);
-    MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+
+    MsRdpEx_RdpInstance_DumpFrameWithCursor(instance);
     MsRdpEx_OutputMirror_Unlock(outputMirror);
 
     captured = true;
 end:
+    if (instance)
+        instance->Release();
+
     return captured;
 }
 
@@ -567,6 +572,29 @@ BOOL WINAPI Hook_StretchBlt(
 
 end:
     return status;
+}
+
+HCURSOR (WINAPI * Real_SetCursor)(HCURSOR hCursor) = SetCursor;
+BOOL (WINAPI * Real_GetCursorPos)(LPPOINT lpPoint) = GetCursorPos;
+
+HCURSOR WINAPI Hook_SetCursor(HCURSOR hCursor)
+{
+    HCURSOR result = Real_SetCursor(hCursor);
+    POINT point = { 0 };
+
+    if (Real_GetCursorPos(&point))
+    {
+        IMsRdpExInstance* instance =
+            MsRdpEx_InstanceManager_AcquireByScreenPoint(point);
+
+        if (instance)
+        {
+            MsRdpEx_RdpInstance_SetCursor(instance, hCursor);
+            instance->Release();
+        }
+    }
+
+    return result;
 }
 
 #define SYSMENU_RDP_RANGE_FIRST_ID               7100
@@ -760,6 +788,7 @@ LRESULT CALLBACK Hook_IHWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     LRESULT result;
     char* lpWindowNameA = NULL;
     IMsRdpExInstance* instance = NULL;
+    bool releaseInstance = false;
     CMsRdpExtendedSettings* pExtendedSettings = NULL;
 
     //MsRdpEx_LogPrint(DEBUG, "IHWndProc: %s (%d)", MsRdpEx_GetWindowMessageName(uMsg), uMsg);
@@ -772,7 +801,8 @@ LRESULT CALLBACK Hook_IHWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     }
     else
     {
-        instance = (IMsRdpExInstance*)MsRdpEx_InstanceManager_FindByInputCaptureHwnd(hWnd);
+        instance = MsRdpEx_InstanceManager_AcquireByInputCaptureHwnd(hWnd);
+        releaseInstance = (instance != NULL);
 
         if (instance)
             instance->GetExtendedSettings(&pExtendedSettings);
@@ -958,8 +988,17 @@ LRESULT CALLBACK Hook_IHWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
         if (instance)
         {
+            TRACKMOUSEEVENT trackMouseEvent = { sizeof(TRACKMOUSEEVENT), TME_LEAVE, hWnd, 0 };
+            TrackMouseEvent(&trackMouseEvent);
             instance->SetLastMousePosition(mousePosX, mousePosY);
+            MsRdpEx_RdpInstance_SetCursor(instance, GetCursor());
+            MsRdpEx_RdpInstance_UpdateCursorPosition(instance, hWnd, mousePosX, mousePosY);
         }
+    }
+    else if (uMsg == WM_MOUSELEAVE)
+    {
+        if (instance)
+            MsRdpEx_RdpInstance_HideCursor(instance);
     }
     else if (uMsg == WM_KEYDOWN)
     {
@@ -1031,6 +1070,9 @@ LRESULT CALLBACK Hook_IHWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     }
 
     free(lpWindowNameA);
+
+    if (releaseInstance)
+        instance->Release();
 
     return result;
 }
@@ -1620,6 +1662,7 @@ LONG MsRdpEx_AttachHooks()
 
     MSRDPEX_DETOUR_ATTACH(Real_BitBlt, Hook_BitBlt);
     MSRDPEX_DETOUR_ATTACH(Real_StretchBlt, Hook_StretchBlt);
+    MSRDPEX_DETOUR_ATTACH(Real_SetCursor, Hook_SetCursor);
     MSRDPEX_DETOUR_ATTACH(Real_RegisterClassExW, Hook_RegisterClassExW);
     MSRDPEX_DETOUR_ATTACH(Real_RegisterClassW, Hook_RegisterClassW);
     MSRDPEX_DETOUR_ATTACH(Real_GetClassInfoW, Hook_GetClassInfoW);
@@ -1679,6 +1722,7 @@ LONG MsRdpEx_DetachHooks()
     
     MSRDPEX_DETOUR_DETACH(Real_BitBlt, Hook_BitBlt);
     MSRDPEX_DETOUR_DETACH(Real_StretchBlt, Hook_StretchBlt);
+    MSRDPEX_DETOUR_DETACH(Real_SetCursor, Hook_SetCursor);
     MSRDPEX_DETOUR_DETACH(Real_RegisterClassExW, Hook_RegisterClassExW);
     MSRDPEX_DETOUR_DETACH(Real_RegisterClassW, Hook_RegisterClassW);
     MSRDPEX_DETOUR_DETACH(Real_GetClassInfoW, Hook_GetClassInfoW);

--- a/dll/CMakeLists.txt
+++ b/dll/CMakeLists.txt
@@ -57,6 +57,8 @@ set(MSRDPEX_SOURCES
     MsRdpClient.cpp
     MsRdpClient.h
     ApiHooks.cpp
+    CursorOverlay.c
+    CursorOverlay.h
     OutputMirror.c
     VideoRecorder.c
     RecordingManifest.c
@@ -68,6 +70,7 @@ set(MSRDPEX_SOURCES
     RdpCoreApi.cpp
     RdpProcess.cpp
     RdpInstance.cpp
+    RdpInstanceInternal.h
     RdpSettings.cpp
     RdpDvcClient.cpp
     RdpDvcClient.h

--- a/dll/CursorOverlay.c
+++ b/dll/CursorOverlay.c
@@ -228,6 +228,10 @@ void MsRdpEx_CursorOverlay_Composite(
 	if (!ctx || !shadowDC)
 		return;
 
+	// Undo a prior composite that never got its Restore (e.g. RDM's read threw between
+	// LockShadowBitmap/UnlockShadowBitmap) so we don't bake a stale cursor into the save surface.
+	MsRdpEx_CursorOverlay_Restore(ctx, outputMirror);
+
 	EnterCriticalSection(&ctx->lock);
 
 	ctx->composited = false;

--- a/dll/CursorOverlay.c
+++ b/dll/CursorOverlay.c
@@ -9,8 +9,8 @@ struct _MsRdpEx_CursorOverlay
 	int32_t hotY;
 	int32_t width;
 	int32_t height;
-	int32_t x;
-	int32_t y;
+	int32_t inputX;
+	int32_t inputY;
 	bool visible;
 	ULONGLONG lastEmitTick;
 
@@ -194,10 +194,10 @@ bool MsRdpEx_CursorOverlay_SetPosition(MsRdpEx_CursorOverlay* ctx, int32_t x, in
 
 	visible = visible && (ctx->cursor != NULL);
 	bool visibilityChanged = (ctx->visible != visible);
-	bool positionChanged = (ctx->x != x) || (ctx->y != y);
+	bool positionChanged = (ctx->inputX != x) || (ctx->inputY != y);
 
-	ctx->x = x;
-	ctx->y = y;
+	ctx->inputX = x;
+	ctx->inputY = y;
 	ctx->visible = visible;
 
 	if ((visibilityChanged || positionChanged) &&
@@ -211,7 +211,9 @@ bool MsRdpEx_CursorOverlay_SetPosition(MsRdpEx_CursorOverlay* ctx, int32_t x, in
 	return emit;
 }
 
-void MsRdpEx_CursorOverlay_DumpFrame(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror)
+void MsRdpEx_CursorOverlay_DumpFrame(
+	MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror,
+	HWND inputWindow, HWND outputWindow)
 {
 	HDC shadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
 	if (!ctx || !shadowDC)
@@ -222,7 +224,36 @@ void MsRdpEx_CursorOverlay_DumpFrame(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputM
 
 	EnterCriticalSection(&ctx->lock);
 
-	if (!ctx->visible || !ctx->cursor || (ctx->width <= 0) || (ctx->height <= 0))
+	if (!ctx->visible || !ctx->cursor || (ctx->width <= 0) || (ctx->height <= 0) ||
+		!IsWindow(inputWindow) || !IsWindow(outputWindow))
+	{
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+		LeaveCriticalSection(&ctx->lock);
+		return;
+	}
+
+	POINT point = { ctx->inputX, ctx->inputY };
+	RECT inputRect = { 0 };
+	RECT outputRect = { 0 };
+
+	if (!GetClientRect(inputWindow, &inputRect) || !PtInRect(&inputRect, point))
+	{
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+		LeaveCriticalSection(&ctx->lock);
+		return;
+	}
+
+	SetLastError(ERROR_SUCCESS);
+	int mapResult = MapWindowPoints(inputWindow, outputWindow, &point, 1);
+
+	if ((mapResult == 0) && (GetLastError() != ERROR_SUCCESS))
+	{
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+		LeaveCriticalSection(&ctx->lock);
+		return;
+	}
+
+	if (!GetClientRect(outputWindow, &outputRect) || !PtInRect(&outputRect, point))
 	{
 		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
 		LeaveCriticalSection(&ctx->lock);
@@ -233,8 +264,8 @@ void MsRdpEx_CursorOverlay_DumpFrame(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputM
 	uint32_t frameHeight = 0;
 	MsRdpEx_OutputMirror_GetFrameSize(outputMirror, &frameWidth, &frameHeight);
 
-	int32_t cursorX = ctx->x - ctx->hotX;
-	int32_t cursorY = ctx->y - ctx->hotY;
+	int32_t cursorX = point.x - ctx->hotX;
+	int32_t cursorY = point.y - ctx->hotY;
 	int32_t left = max(cursorX, 0);
 	int32_t top = max(cursorY, 0);
 	int32_t right = min(cursorX + ctx->width, (int32_t)frameWidth);

--- a/dll/CursorOverlay.c
+++ b/dll/CursorOverlay.c
@@ -20,6 +20,15 @@ struct _MsRdpEx_CursorOverlay
 	int32_t saveWidth;
 	int32_t saveHeight;
 
+	// Composite() draws the cursor and stashes the region it overwrote here; Restore() puts it back.
+	// They run at separate times (e.g. RDM reads the shadow between LockShadowBitmap/UnlockShadowBitmap),
+	// so the pending-restore state has to survive between the two calls.
+	bool composited;
+	int32_t restoreLeft;
+	int32_t restoreTop;
+	int32_t restoreWidth;
+	int32_t restoreHeight;
+
 	CRITICAL_SECTION lock;
 };
 
@@ -211,23 +220,21 @@ bool MsRdpEx_CursorOverlay_SetPosition(MsRdpEx_CursorOverlay* ctx, int32_t x, in
 	return emit;
 }
 
-void MsRdpEx_CursorOverlay_DumpFrame(
+void MsRdpEx_CursorOverlay_Composite(
 	MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror,
 	HWND inputWindow, HWND outputWindow)
 {
 	HDC shadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
 	if (!ctx || !shadowDC)
-	{
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
 		return;
-	}
 
 	EnterCriticalSection(&ctx->lock);
+
+	ctx->composited = false;
 
 	if (!ctx->visible || !ctx->cursor || (ctx->width <= 0) || (ctx->height <= 0) ||
 		!IsWindow(inputWindow) || !IsWindow(outputWindow))
 	{
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
 		LeaveCriticalSection(&ctx->lock);
 		return;
 	}
@@ -238,7 +245,6 @@ void MsRdpEx_CursorOverlay_DumpFrame(
 
 	if (!GetClientRect(inputWindow, &inputRect) || !PtInRect(&inputRect, point))
 	{
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
 		LeaveCriticalSection(&ctx->lock);
 		return;
 	}
@@ -248,14 +254,12 @@ void MsRdpEx_CursorOverlay_DumpFrame(
 
 	if ((mapResult == 0) && (GetLastError() != ERROR_SUCCESS))
 	{
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
 		LeaveCriticalSection(&ctx->lock);
 		return;
 	}
 
 	if (!GetClientRect(outputWindow, &outputRect) || !PtInRect(&outputRect, point))
 	{
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
 		LeaveCriticalSection(&ctx->lock);
 		return;
 	}
@@ -277,22 +281,48 @@ void MsRdpEx_CursorOverlay_DumpFrame(
 		!MsRdpEx_CursorOverlay_EnsureSaveSurface(ctx, shadowDC, copyWidth, copyHeight) ||
 		!BitBlt(ctx->saveDC, 0, 0, copyWidth, copyHeight, shadowDC, left, top, SRCCOPY))
 	{
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
 		LeaveCriticalSection(&ctx->lock);
 		return;
 	}
 
-	BOOL drawn = DrawIconEx(shadowDC, cursorX, cursorY, ctx->cursor, 0, 0, 0, NULL, DI_NORMAL);
-	GdiFlush();
-
-	if (drawn)
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
-
-	BitBlt(shadowDC, left, top, copyWidth, copyHeight, ctx->saveDC, 0, 0, SRCCOPY);
-	GdiFlush();
-
-	if (!drawn)
-		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+	if (DrawIconEx(shadowDC, cursorX, cursorY, ctx->cursor, 0, 0, 0, NULL, DI_NORMAL))
+	{
+		GdiFlush();
+		ctx->composited = true;
+		ctx->restoreLeft = left;
+		ctx->restoreTop = top;
+		ctx->restoreWidth = copyWidth;
+		ctx->restoreHeight = copyHeight;
+	}
 
 	LeaveCriticalSection(&ctx->lock);
+}
+
+void MsRdpEx_CursorOverlay_Restore(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror)
+{
+	HDC shadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
+	if (!ctx || !shadowDC)
+		return;
+
+	EnterCriticalSection(&ctx->lock);
+
+	if (ctx->composited)
+	{
+		BitBlt(shadowDC, ctx->restoreLeft, ctx->restoreTop, ctx->restoreWidth, ctx->restoreHeight,
+			ctx->saveDC, 0, 0, SRCCOPY);
+		GdiFlush();
+		ctx->composited = false;
+	}
+
+	LeaveCriticalSection(&ctx->lock);
+}
+
+// Push path (MsRdpEx's own recorder): draw the cursor, encode the frame, put the pixels back.
+void MsRdpEx_CursorOverlay_DumpFrame(
+	MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror,
+	HWND inputWindow, HWND outputWindow)
+{
+	MsRdpEx_CursorOverlay_Composite(ctx, outputMirror, inputWindow, outputWindow);
+	MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+	MsRdpEx_CursorOverlay_Restore(ctx, outputMirror);
 }

--- a/dll/CursorOverlay.c
+++ b/dll/CursorOverlay.c
@@ -1,0 +1,267 @@
+#include "MsRdpEx.h"
+#include "CursorOverlay.h"
+
+struct _MsRdpEx_CursorOverlay
+{
+	HCURSOR sourceCursor;
+	HCURSOR cursor;
+	int32_t hotX;
+	int32_t hotY;
+	int32_t width;
+	int32_t height;
+	int32_t x;
+	int32_t y;
+	bool visible;
+	ULONGLONG lastEmitTick;
+
+	HDC saveDC;
+	HBITMAP saveBitmap;
+	HGDIOBJ saveOldObject;
+	int32_t saveWidth;
+	int32_t saveHeight;
+
+	CRITICAL_SECTION lock;
+};
+
+static void MsRdpEx_CursorOverlay_FreeSaveSurface(MsRdpEx_CursorOverlay* ctx)
+{
+	if (!ctx->saveDC)
+		return;
+
+	SelectObject(ctx->saveDC, ctx->saveOldObject);
+	DeleteObject(ctx->saveBitmap);
+	DeleteDC(ctx->saveDC);
+
+	ctx->saveDC = NULL;
+	ctx->saveBitmap = NULL;
+	ctx->saveOldObject = NULL;
+	ctx->saveWidth = 0;
+	ctx->saveHeight = 0;
+}
+
+static bool MsRdpEx_CursorOverlay_EnsureSaveSurface(
+	MsRdpEx_CursorOverlay* ctx, HDC shadowDC, int32_t width, int32_t height)
+{
+	if (ctx->saveDC && (width <= ctx->saveWidth) && (height <= ctx->saveHeight))
+		return true;
+
+	HDC saveDC = CreateCompatibleDC(shadowDC);
+	if (!saveDC)
+		return false;
+
+	HBITMAP saveBitmap = CreateCompatibleBitmap(shadowDC, width, height);
+	if (!saveBitmap)
+	{
+		DeleteDC(saveDC);
+		return false;
+	}
+
+	HGDIOBJ saveOldObject = SelectObject(saveDC, saveBitmap);
+	if (!saveOldObject || (saveOldObject == HGDI_ERROR))
+	{
+		DeleteObject(saveBitmap);
+		DeleteDC(saveDC);
+		return false;
+	}
+
+	MsRdpEx_CursorOverlay_FreeSaveSurface(ctx);
+	ctx->saveDC = saveDC;
+	ctx->saveBitmap = saveBitmap;
+	ctx->saveOldObject = saveOldObject;
+	ctx->saveWidth = width;
+	ctx->saveHeight = height;
+
+	return true;
+}
+
+MsRdpEx_CursorOverlay* MsRdpEx_CursorOverlay_New()
+{
+	MsRdpEx_CursorOverlay* ctx = (MsRdpEx_CursorOverlay*)calloc(1, sizeof(MsRdpEx_CursorOverlay));
+	if (!ctx)
+		return NULL;
+
+	InitializeCriticalSectionAndSpinCount(&ctx->lock, 4000);
+	return ctx;
+}
+
+void MsRdpEx_CursorOverlay_Free(MsRdpEx_CursorOverlay* ctx)
+{
+	if (!ctx)
+		return;
+
+	EnterCriticalSection(&ctx->lock);
+	MsRdpEx_CursorOverlay_FreeSaveSurface(ctx);
+
+	if (ctx->cursor)
+		DestroyIcon(ctx->cursor);
+
+	LeaveCriticalSection(&ctx->lock);
+	DeleteCriticalSection(&ctx->lock);
+	free(ctx);
+}
+
+bool MsRdpEx_CursorOverlay_SetShape(MsRdpEx_CursorOverlay* ctx, HCURSOR cursor)
+{
+	bool changed = false;
+	HCURSOR cursorCopy = NULL;
+	ICONINFO iconInfo = { 0 };
+	BITMAP bitmap = { 0 };
+	int32_t hotX = 0;
+	int32_t hotY = 0;
+	int32_t width = 0;
+	int32_t height = 0;
+
+	EnterCriticalSection(&ctx->lock);
+	bool unchanged = (cursor == ctx->sourceCursor);
+	LeaveCriticalSection(&ctx->lock);
+
+	if (unchanged)
+		return false;
+
+	if (cursor)
+	{
+		cursorCopy = (HCURSOR)CopyIcon(cursor);
+		if (!cursorCopy || !GetIconInfo(cursorCopy, &iconInfo))
+		{
+			if (cursorCopy)
+				DestroyIcon(cursorCopy);
+			return false;
+		}
+
+		HBITMAP sizeBitmap = iconInfo.hbmColor ? iconInfo.hbmColor : iconInfo.hbmMask;
+		if (!sizeBitmap || !GetObject(sizeBitmap, sizeof(BITMAP), &bitmap))
+		{
+			DeleteObject(iconInfo.hbmMask);
+			if (iconInfo.hbmColor)
+				DeleteObject(iconInfo.hbmColor);
+			DestroyIcon(cursorCopy);
+			return false;
+		}
+
+		hotX = (int32_t)iconInfo.xHotspot;
+		hotY = (int32_t)iconInfo.yHotspot;
+		width = bitmap.bmWidth;
+		height = (!iconInfo.hbmColor && iconInfo.hbmMask) ? (bitmap.bmHeight / 2) : bitmap.bmHeight;
+	}
+
+	EnterCriticalSection(&ctx->lock);
+
+	if (cursor != ctx->sourceCursor)
+	{
+		if (ctx->cursor)
+			DestroyIcon(ctx->cursor);
+
+		ctx->sourceCursor = cursor;
+		ctx->cursor = cursorCopy;
+		cursorCopy = NULL;
+		changed = true;
+
+		if (cursor)
+		{
+			ctx->hotX = hotX;
+			ctx->hotY = hotY;
+			ctx->width = width;
+			ctx->height = height;
+		}
+		else
+		{
+			ctx->visible = false;
+			ctx->width = 0;
+			ctx->height = 0;
+		}
+	}
+
+	LeaveCriticalSection(&ctx->lock);
+
+	if (iconInfo.hbmMask)
+		DeleteObject(iconInfo.hbmMask);
+
+	if (iconInfo.hbmColor)
+		DeleteObject(iconInfo.hbmColor);
+
+	if (cursorCopy)
+		DestroyIcon(cursorCopy);
+
+	return changed;
+}
+
+bool MsRdpEx_CursorOverlay_SetPosition(MsRdpEx_CursorOverlay* ctx, int32_t x, int32_t y, bool visible)
+{
+	bool emit = false;
+	ULONGLONG now = GetTickCount64();
+
+	EnterCriticalSection(&ctx->lock);
+
+	visible = visible && (ctx->cursor != NULL);
+	bool visibilityChanged = (ctx->visible != visible);
+	bool positionChanged = (ctx->x != x) || (ctx->y != y);
+
+	ctx->x = x;
+	ctx->y = y;
+	ctx->visible = visible;
+
+	if ((visibilityChanged || positionChanged) &&
+		(visibilityChanged || ((now - ctx->lastEmitTick) >= 30)))
+	{
+		ctx->lastEmitTick = now;
+		emit = true;
+	}
+
+	LeaveCriticalSection(&ctx->lock);
+	return emit;
+}
+
+void MsRdpEx_CursorOverlay_DumpFrame(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror)
+{
+	HDC shadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
+	if (!ctx || !shadowDC)
+	{
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+		return;
+	}
+
+	EnterCriticalSection(&ctx->lock);
+
+	if (!ctx->visible || !ctx->cursor || (ctx->width <= 0) || (ctx->height <= 0))
+	{
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+		LeaveCriticalSection(&ctx->lock);
+		return;
+	}
+
+	uint32_t frameWidth = 0;
+	uint32_t frameHeight = 0;
+	MsRdpEx_OutputMirror_GetFrameSize(outputMirror, &frameWidth, &frameHeight);
+
+	int32_t cursorX = ctx->x - ctx->hotX;
+	int32_t cursorY = ctx->y - ctx->hotY;
+	int32_t left = max(cursorX, 0);
+	int32_t top = max(cursorY, 0);
+	int32_t right = min(cursorX + ctx->width, (int32_t)frameWidth);
+	int32_t bottom = min(cursorY + ctx->height, (int32_t)frameHeight);
+	int32_t copyWidth = right - left;
+	int32_t copyHeight = bottom - top;
+
+	if ((copyWidth <= 0) || (copyHeight <= 0) ||
+		!MsRdpEx_CursorOverlay_EnsureSaveSurface(ctx, shadowDC, copyWidth, copyHeight) ||
+		!BitBlt(ctx->saveDC, 0, 0, copyWidth, copyHeight, shadowDC, left, top, SRCCOPY))
+	{
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+		LeaveCriticalSection(&ctx->lock);
+		return;
+	}
+
+	BOOL drawn = DrawIconEx(shadowDC, cursorX, cursorY, ctx->cursor, 0, 0, 0, NULL, DI_NORMAL);
+	GdiFlush();
+
+	if (drawn)
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+
+	BitBlt(shadowDC, left, top, copyWidth, copyHeight, ctx->saveDC, 0, 0, SRCCOPY);
+	GdiFlush();
+
+	if (!drawn)
+		MsRdpEx_OutputMirror_DumpFrame(outputMirror);
+
+	LeaveCriticalSection(&ctx->lock);
+}

--- a/dll/CursorOverlay.h
+++ b/dll/CursorOverlay.h
@@ -14,7 +14,9 @@ void MsRdpEx_CursorOverlay_Free(MsRdpEx_CursorOverlay* ctx);
 
 bool MsRdpEx_CursorOverlay_SetShape(MsRdpEx_CursorOverlay* ctx, HCURSOR cursor);
 bool MsRdpEx_CursorOverlay_SetPosition(MsRdpEx_CursorOverlay* ctx, int32_t x, int32_t y, bool visible);
-void MsRdpEx_CursorOverlay_DumpFrame(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror);
+void MsRdpEx_CursorOverlay_DumpFrame(
+	MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror,
+	HWND inputWindow, HWND outputWindow);
 
 #ifdef __cplusplus
 }

--- a/dll/CursorOverlay.h
+++ b/dll/CursorOverlay.h
@@ -14,6 +14,10 @@ void MsRdpEx_CursorOverlay_Free(MsRdpEx_CursorOverlay* ctx);
 
 bool MsRdpEx_CursorOverlay_SetShape(MsRdpEx_CursorOverlay* ctx, HCURSOR cursor);
 bool MsRdpEx_CursorOverlay_SetPosition(MsRdpEx_CursorOverlay* ctx, int32_t x, int32_t y, bool visible);
+void MsRdpEx_CursorOverlay_Composite(
+	MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror,
+	HWND inputWindow, HWND outputWindow);
+void MsRdpEx_CursorOverlay_Restore(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror);
 void MsRdpEx_CursorOverlay_DumpFrame(
 	MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror,
 	HWND inputWindow, HWND outputWindow);

--- a/dll/CursorOverlay.h
+++ b/dll/CursorOverlay.h
@@ -1,0 +1,23 @@
+#ifndef MSRDPEX_CURSOR_OVERLAY_H
+#define MSRDPEX_CURSOR_OVERLAY_H
+
+#include <MsRdpEx/OutputMirror.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _MsRdpEx_CursorOverlay MsRdpEx_CursorOverlay;
+
+MsRdpEx_CursorOverlay* MsRdpEx_CursorOverlay_New();
+void MsRdpEx_CursorOverlay_Free(MsRdpEx_CursorOverlay* ctx);
+
+bool MsRdpEx_CursorOverlay_SetShape(MsRdpEx_CursorOverlay* ctx, HCURSOR cursor);
+bool MsRdpEx_CursorOverlay_SetPosition(MsRdpEx_CursorOverlay* ctx, int32_t x, int32_t y, bool visible);
+void MsRdpEx_CursorOverlay_DumpFrame(MsRdpEx_CursorOverlay* ctx, MsRdpEx_OutputMirror* outputMirror);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MSRDPEX_CURSOR_OVERLAY_H */

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -7,6 +7,8 @@
 
 #include "TSObjects.h"
 #include "ComHelpers.h"
+#include "CursorOverlay.h"
+#include "RdpInstanceInternal.h"
 
 extern "C" const GUID IID_IMsRdpExInstance;
 
@@ -17,6 +19,7 @@ public:
     {
         m_refCount = 1;
         m_pMsRdpClient = pMsRdpClient;
+        m_CursorOverlay = MsRdpEx_CursorOverlay_New();
         MsRdpEx_GuidGenerate(&m_sessionId);
 
         char sessionId[MSRDPEX_GUID_STRING_SIZE];
@@ -26,6 +29,11 @@ public:
 
     ~CMsRdpExInstance()
     {
+        if (m_CursorOverlay) {
+            MsRdpEx_CursorOverlay_Free(m_CursorOverlay);
+            m_CursorOverlay = NULL;
+        }
+
         if (m_OutputMirror) {
             MsRdpEx_OutputMirror_Free(m_OutputMirror);
             m_OutputMirror = NULL;
@@ -292,6 +300,67 @@ public:
         m_LastMousePosY = posY;
     }
 
+    void SetCursor(HCURSOR cursor)
+    {
+        if (!m_CursorOverlay)
+            return;
+
+        if (MsRdpEx_CursorOverlay_SetShape(m_CursorOverlay, cursor))
+            EmitCursorFrame();
+    }
+
+    void UpdateCursorPosition(HWND sourceWindow, int32_t posX, int32_t posY)
+    {
+        if (!m_CursorOverlay || !sourceWindow || !m_hOutputPresenterWnd)
+            return;
+
+        POINT point = { posX, posY };
+        MapWindowPoints(sourceWindow, m_hOutputPresenterWnd, &point, 1);
+
+        RECT rect = { 0 };
+        bool visible = GetClientRect(m_hOutputPresenterWnd, &rect) &&
+            (point.x >= rect.left) && (point.y >= rect.top) &&
+            (point.x < rect.right) && (point.y < rect.bottom);
+
+        if (MsRdpEx_CursorOverlay_SetPosition(m_CursorOverlay, point.x, point.y, visible))
+            EmitCursorFrame();
+    }
+
+    void HideCursor()
+    {
+        if (!m_CursorOverlay)
+            return;
+
+        if (MsRdpEx_CursorOverlay_SetPosition(
+            m_CursorOverlay, m_LastMousePosX, m_LastMousePosY, false))
+        {
+            EmitCursorFrame();
+        }
+    }
+
+    void DumpFrameWithCursor()
+    {
+        if (!m_OutputMirror)
+            return;
+
+        if (m_CursorOverlay)
+            MsRdpEx_CursorOverlay_DumpFrame(m_CursorOverlay, m_OutputMirror);
+        else
+            MsRdpEx_OutputMirror_DumpFrame(m_OutputMirror);
+    }
+
+private:
+    void EmitCursorFrame()
+    {
+        if (!m_OutputMirror)
+            return;
+
+        MsRdpEx_OutputMirror_Lock(m_OutputMirror);
+        MsRdpEx_CursorOverlay_DumpFrame(m_CursorOverlay, m_OutputMirror);
+        MsRdpEx_OutputMirror_Unlock(m_OutputMirror);
+    }
+
+public:
     HRESULT STDMETHODCALLTYPE GetWTSPluginObject(LPVOID* ppvObject)
     {
         *ppvObject = m_WTSPlugin;
@@ -311,6 +380,7 @@ public:
     HWND m_hInputCaptureWnd = NULL;
     HWND m_hOutputPresenterWnd = NULL;
     HWND m_hTscShellContainerWnd = NULL;
+    MsRdpEx_CursorOverlay* m_CursorOverlay = NULL;
     MsRdpEx_OutputMirror* m_OutputMirror = NULL;
     ITSPropertySet* m_pCorePropsRaw = NULL;
     CMsRdpExtendedSettings* m_pMsRdpExtendedSettings = NULL;
@@ -328,6 +398,27 @@ CMsRdpExInstance* CMsRdpExInstance_New(CMsRdpClient* pMsRdpClient)
 void MsRdpEx_RdpInstance_Free(CMsRdpExInstance* instance)
 {
     instance->Release();
+}
+
+void MsRdpEx_RdpInstance_SetCursor(IMsRdpExInstance* instance, HCURSOR cursor)
+{
+    ((CMsRdpExInstance*)instance)->SetCursor(cursor);
+}
+
+void MsRdpEx_RdpInstance_UpdateCursorPosition(
+    IMsRdpExInstance* instance, HWND sourceWindow, int32_t x, int32_t y)
+{
+    ((CMsRdpExInstance*)instance)->UpdateCursorPosition(sourceWindow, x, y);
+}
+
+void MsRdpEx_RdpInstance_HideCursor(IMsRdpExInstance* instance)
+{
+    ((CMsRdpExInstance*)instance)->HideCursor();
+}
+
+void MsRdpEx_RdpInstance_DumpFrameWithCursor(IMsRdpExInstance* instance)
+{
+    ((CMsRdpExInstance*)instance)->DumpFrameWithCursor();
 }
 
 typedef struct _MsRdpEx_InstanceManager MsRdpEx_InstanceManager;
@@ -394,6 +485,34 @@ CMsRdpExInstance* MsRdpEx_InstanceManager_FindByOutputPresenterHwnd(HWND hWnd)
     MsRdpEx_ArrayListIt_Finish(it);
 
     return found ? obj : NULL;
+}
+
+IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByOutputPresenterHwnd(HWND hWnd)
+{
+    MsRdpEx_InstanceManager* ctx = g_InstanceManager;
+
+    if (!ctx)
+        return NULL;
+
+    CMsRdpExInstance* instance = NULL;
+    MsRdpEx_ArrayListIt* it = MsRdpEx_ArrayList_It(
+        ctx->instances, MSRDPEX_ITERATOR_FLAG_EXCLUSIVE);
+
+    while (!MsRdpEx_ArrayListIt_Done(it))
+    {
+        CMsRdpExInstance* candidate =
+            (CMsRdpExInstance*)MsRdpEx_ArrayListIt_Next(it);
+
+        if (candidate->m_hOutputPresenterWnd == hWnd)
+        {
+            instance = candidate;
+            instance->AddRef();
+            break;
+        }
+    }
+
+    MsRdpEx_ArrayListIt_Finish(it);
+    return instance;
 }
 
 CMsRdpExInstance* MsRdpEx_InstanceManager_AttachOutputWindow(HWND hOutputWnd, void* pUserData)
@@ -488,6 +607,70 @@ CMsRdpExInstance* MsRdpEx_InstanceManager_FindByInputCaptureHwnd(HWND hWnd)
     MsRdpEx_ArrayListIt_Finish(it);
 
     return found ? obj : NULL;
+}
+
+IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByInputCaptureHwnd(HWND hWnd)
+{
+    MsRdpEx_InstanceManager* ctx = g_InstanceManager;
+
+    if (!ctx)
+        return NULL;
+
+    CMsRdpExInstance* instance = NULL;
+    MsRdpEx_ArrayListIt* it = MsRdpEx_ArrayList_It(
+        ctx->instances, MSRDPEX_ITERATOR_FLAG_EXCLUSIVE);
+
+    while (!MsRdpEx_ArrayListIt_Done(it))
+    {
+        CMsRdpExInstance* candidate =
+            (CMsRdpExInstance*)MsRdpEx_ArrayListIt_Next(it);
+
+        if (candidate->m_hInputCaptureWnd == hWnd)
+        {
+            instance = candidate;
+            instance->AddRef();
+            break;
+        }
+    }
+
+    MsRdpEx_ArrayListIt_Finish(it);
+    return instance;
+}
+
+IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByScreenPoint(POINT point)
+{
+    MsRdpEx_InstanceManager* ctx = g_InstanceManager;
+    HWND pointWindow = WindowFromPoint(point);
+
+    if (!ctx || !pointWindow)
+        return NULL;
+
+    CMsRdpExInstance* instance = NULL;
+    MsRdpEx_ArrayListIt* it = MsRdpEx_ArrayList_It(
+        ctx->instances, MSRDPEX_ITERATOR_FLAG_EXCLUSIVE);
+
+    while (!MsRdpEx_ArrayListIt_Done(it))
+    {
+        CMsRdpExInstance* candidate =
+            (CMsRdpExInstance*)MsRdpEx_ArrayListIt_Next(it);
+
+        bool matchesInput = candidate->m_hInputCaptureWnd &&
+            ((pointWindow == candidate->m_hInputCaptureWnd) ||
+                IsChild(candidate->m_hInputCaptureWnd, pointWindow));
+        bool matchesOutput = candidate->m_hOutputPresenterWnd &&
+            ((pointWindow == candidate->m_hOutputPresenterWnd) ||
+                IsChild(candidate->m_hOutputPresenterWnd, pointWindow));
+
+        if (matchesInput || matchesOutput)
+        {
+            instance = candidate;
+            instance->AddRef();
+            break;
+        }
+    }
+
+    MsRdpEx_ArrayListIt_Finish(it);
+    return instance;
 }
 
 CMsRdpExInstance* MsRdpEx_InstanceManager_AttachInputWindow(HWND hInputWnd, void* pUserData)

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -300,7 +300,7 @@ public:
         m_LastMousePosY = posY;
     }
 
-    void SetCursor(HCURSOR cursor)
+    void STDMETHODCALLTYPE SetCursor(HCURSOR cursor)
     {
         if (!m_CursorOverlay)
             return;
@@ -309,24 +309,16 @@ public:
             EmitCursorFrame();
     }
 
-    void UpdateCursorPosition(HWND sourceWindow, int32_t posX, int32_t posY)
+    void STDMETHODCALLTYPE UpdateCursorPosition(int32_t posX, int32_t posY)
     {
-        if (!m_CursorOverlay || !sourceWindow || !m_hOutputPresenterWnd)
+        if (!m_CursorOverlay)
             return;
 
-        POINT point = { posX, posY };
-        MapWindowPoints(sourceWindow, m_hOutputPresenterWnd, &point, 1);
-
-        RECT rect = { 0 };
-        bool visible = GetClientRect(m_hOutputPresenterWnd, &rect) &&
-            (point.x >= rect.left) && (point.y >= rect.top) &&
-            (point.x < rect.right) && (point.y < rect.bottom);
-
-        if (MsRdpEx_CursorOverlay_SetPosition(m_CursorOverlay, point.x, point.y, visible))
+        if (MsRdpEx_CursorOverlay_SetPosition(m_CursorOverlay, posX, posY, true))
             EmitCursorFrame();
     }
 
-    void HideCursor()
+    void STDMETHODCALLTYPE HideCursor()
     {
         if (!m_CursorOverlay)
             return;
@@ -338,13 +330,15 @@ public:
         }
     }
 
-    void DumpFrameWithCursor()
+    void STDMETHODCALLTYPE DumpFrameWithCursor()
     {
         if (!m_OutputMirror)
             return;
 
         if (m_CursorOverlay)
-            MsRdpEx_CursorOverlay_DumpFrame(m_CursorOverlay, m_OutputMirror);
+            MsRdpEx_CursorOverlay_DumpFrame(
+                m_CursorOverlay, m_OutputMirror,
+                m_hInputCaptureWnd, m_hOutputPresenterWnd);
         else
             MsRdpEx_OutputMirror_DumpFrame(m_OutputMirror);
     }
@@ -356,7 +350,9 @@ private:
             return;
 
         MsRdpEx_OutputMirror_Lock(m_OutputMirror);
-        MsRdpEx_CursorOverlay_DumpFrame(m_CursorOverlay, m_OutputMirror);
+        MsRdpEx_CursorOverlay_DumpFrame(
+            m_CursorOverlay, m_OutputMirror,
+            m_hInputCaptureWnd, m_hOutputPresenterWnd);
         MsRdpEx_OutputMirror_Unlock(m_OutputMirror);
     }
 
@@ -398,27 +394,6 @@ CMsRdpExInstance* CMsRdpExInstance_New(CMsRdpClient* pMsRdpClient)
 void MsRdpEx_RdpInstance_Free(CMsRdpExInstance* instance)
 {
     instance->Release();
-}
-
-void MsRdpEx_RdpInstance_SetCursor(IMsRdpExInstance* instance, HCURSOR cursor)
-{
-    ((CMsRdpExInstance*)instance)->SetCursor(cursor);
-}
-
-void MsRdpEx_RdpInstance_UpdateCursorPosition(
-    IMsRdpExInstance* instance, HWND sourceWindow, int32_t x, int32_t y)
-{
-    ((CMsRdpExInstance*)instance)->UpdateCursorPosition(sourceWindow, x, y);
-}
-
-void MsRdpEx_RdpInstance_HideCursor(IMsRdpExInstance* instance)
-{
-    ((CMsRdpExInstance*)instance)->HideCursor();
-}
-
-void MsRdpEx_RdpInstance_DumpFrameWithCursor(IMsRdpExInstance* instance)
-{
-    ((CMsRdpExInstance*)instance)->DumpFrameWithCursor();
 }
 
 typedef struct _MsRdpEx_InstanceManager MsRdpEx_InstanceManager;
@@ -626,42 +601,6 @@ IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByInputCaptureHwnd(HWND hWnd)
             (CMsRdpExInstance*)MsRdpEx_ArrayListIt_Next(it);
 
         if (candidate->m_hInputCaptureWnd == hWnd)
-        {
-            instance = candidate;
-            instance->AddRef();
-            break;
-        }
-    }
-
-    MsRdpEx_ArrayListIt_Finish(it);
-    return instance;
-}
-
-IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByScreenPoint(POINT point)
-{
-    MsRdpEx_InstanceManager* ctx = g_InstanceManager;
-    HWND pointWindow = WindowFromPoint(point);
-
-    if (!ctx || !pointWindow)
-        return NULL;
-
-    CMsRdpExInstance* instance = NULL;
-    MsRdpEx_ArrayListIt* it = MsRdpEx_ArrayList_It(
-        ctx->instances, MSRDPEX_ITERATOR_FLAG_EXCLUSIVE);
-
-    while (!MsRdpEx_ArrayListIt_Done(it))
-    {
-        CMsRdpExInstance* candidate =
-            (CMsRdpExInstance*)MsRdpEx_ArrayListIt_Next(it);
-
-        bool matchesInput = candidate->m_hInputCaptureWnd &&
-            ((pointWindow == candidate->m_hInputCaptureWnd) ||
-                IsChild(candidate->m_hInputCaptureWnd, pointWindow));
-        bool matchesOutput = candidate->m_hOutputPresenterWnd &&
-            ((pointWindow == candidate->m_hOutputPresenterWnd) ||
-                IsChild(candidate->m_hOutputPresenterWnd, pointWindow));
-
-        if (matchesInput || matchesOutput)
         {
             instance = candidate;
             instance->AddRef();

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -290,7 +290,7 @@ public:
         if (!outputMirror)
             return;
 
-        if (m_CursorOverlay && IsCursorOverlayEnabled())
+        if (m_CursorOverlay)
             MsRdpEx_CursorOverlay_Restore(m_CursorOverlay, outputMirror);
 
         MsRdpEx_OutputMirror_Unlock(outputMirror);

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -276,6 +276,11 @@ public:
             return;
 
         MsRdpEx_OutputMirror_Lock(outputMirror);
+
+        // RDM reads the shadow bitmap between Lock and Unlock (RdpAxThumbnailManager), so draw the
+        // cursor now and undo it in Unlock - that read is what carries the cursor into RDM's recording.
+        if (m_CursorOverlay && IsCursorOverlayEnabled())
+            MsRdpEx_CursorOverlay_Composite(m_CursorOverlay, outputMirror, m_hInputCaptureWnd, m_hOutputPresenterWnd);
     }
 
     void STDMETHODCALLTYPE UnlockShadowBitmap()
@@ -284,6 +289,9 @@ public:
 
         if (!outputMirror)
             return;
+
+        if (m_CursorOverlay && IsCursorOverlayEnabled())
+            MsRdpEx_CursorOverlay_Restore(m_CursorOverlay, outputMirror);
 
         MsRdpEx_OutputMirror_Unlock(outputMirror);
     }
@@ -302,7 +310,7 @@ public:
 
     void STDMETHODCALLTYPE SetCursor(HCURSOR cursor)
     {
-        if (!m_CursorOverlay)
+        if (!m_CursorOverlay || !IsCursorOverlayEnabled())
             return;
 
         if (MsRdpEx_CursorOverlay_SetShape(m_CursorOverlay, cursor))
@@ -311,7 +319,7 @@ public:
 
     void STDMETHODCALLTYPE UpdateCursorPosition(int32_t posX, int32_t posY)
     {
-        if (!m_CursorOverlay)
+        if (!m_CursorOverlay || !IsCursorOverlayEnabled())
             return;
 
         if (MsRdpEx_CursorOverlay_SetPosition(m_CursorOverlay, posX, posY, true))
@@ -320,7 +328,7 @@ public:
 
     void STDMETHODCALLTYPE HideCursor()
     {
-        if (!m_CursorOverlay)
+        if (!m_CursorOverlay || !IsCursorOverlayEnabled())
             return;
 
         if (MsRdpEx_CursorOverlay_SetPosition(
@@ -335,7 +343,7 @@ public:
         if (!m_OutputMirror)
             return;
 
-        if (m_CursorOverlay)
+        if (m_CursorOverlay && IsCursorOverlayEnabled())
             MsRdpEx_CursorOverlay_DumpFrame(
                 m_CursorOverlay, m_OutputMirror,
                 m_hInputCaptureWnd, m_hOutputPresenterWnd);
@@ -344,9 +352,18 @@ public:
     }
 
 private:
+    bool IsCursorOverlayEnabled()
+    {
+        return m_pMsRdpExtendedSettings && m_pMsRdpExtendedSettings->GetVideoRecordingCursor();
+    }
+
     void EmitCursorFrame()
     {
-        if (!m_OutputMirror)
+        if (!m_OutputMirror || !IsCursorOverlayEnabled())
+            return;
+
+        bool outputMirrorEnabled = false;
+        if (FAILED(GetOutputMirrorEnabled(&outputMirrorEnabled)) || !outputMirrorEnabled)
             return;
 
         MsRdpEx_OutputMirror_Lock(m_OutputMirror);

--- a/dll/RdpInstanceInternal.h
+++ b/dll/RdpInstanceInternal.h
@@ -1,0 +1,16 @@
+#ifndef MSRDPEX_RDP_INSTANCE_INTERNAL_H
+#define MSRDPEX_RDP_INSTANCE_INTERNAL_H
+
+#include <MsRdpEx/RdpInstance.h>
+
+IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByOutputPresenterHwnd(HWND hWnd);
+IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByInputCaptureHwnd(HWND hWnd);
+IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByScreenPoint(POINT point);
+
+void MsRdpEx_RdpInstance_SetCursor(IMsRdpExInstance* instance, HCURSOR cursor);
+void MsRdpEx_RdpInstance_UpdateCursorPosition(
+    IMsRdpExInstance* instance, HWND sourceWindow, int32_t x, int32_t y);
+void MsRdpEx_RdpInstance_HideCursor(IMsRdpExInstance* instance);
+void MsRdpEx_RdpInstance_DumpFrameWithCursor(IMsRdpExInstance* instance);
+
+#endif /* MSRDPEX_RDP_INSTANCE_INTERNAL_H */

--- a/dll/RdpInstanceInternal.h
+++ b/dll/RdpInstanceInternal.h
@@ -5,12 +5,5 @@
 
 IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByOutputPresenterHwnd(HWND hWnd);
 IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByInputCaptureHwnd(HWND hWnd);
-IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByScreenPoint(POINT point);
-
-void MsRdpEx_RdpInstance_SetCursor(IMsRdpExInstance* instance, HCURSOR cursor);
-void MsRdpEx_RdpInstance_UpdateCursorPosition(
-    IMsRdpExInstance* instance, HWND sourceWindow, int32_t x, int32_t y);
-void MsRdpEx_RdpInstance_HideCursor(IMsRdpExInstance* instance);
-void MsRdpEx_RdpInstance_DumpFrameWithCursor(IMsRdpExInstance* instance);
 
 #endif /* MSRDPEX_RDP_INSTANCE_INTERNAL_H */

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -655,6 +655,14 @@ CMsRdpExtendedSettings::CMsRdpExtendedSettings(IUnknown* pUnknown, GUID* pSessio
     {
         m_pMsRdpClient7->get_TransportSettings2(&m_pMsRdpClientTransportSettings2);
     }
+
+    // Lets ops/testing force the cursor overlay on without a client that knows the new property.
+    char* cursorEnv = MsRdpEx_GetEnv("MSRDPEX_RECORDING_CURSOR");
+    if (cursorEnv)
+    {
+        m_VideoRecordingCursor = (atoi(cursorEnv) != 0);
+        free(cursorEnv);
+    }
 }
 
 CMsRdpExtendedSettings::~CMsRdpExtendedSettings()
@@ -889,6 +897,15 @@ HRESULT __stdcall CMsRdpExtendedSettings::put_Property(BSTR bstrPropertyName, VA
 
         hr = S_OK;
     }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingCursor"))
+    {
+        if (pValue->vt != VT_BOOL)
+            goto end;
+
+        m_VideoRecordingCursor = pValue->boolVal ? true : false;
+
+        hr = S_OK;
+    }
     else if (MsRdpEx_StringEquals(propName, "RecordingPath"))
     {
         if (pValue->vt != VT_BSTR)
@@ -1037,6 +1054,11 @@ HRESULT __stdcall CMsRdpExtendedSettings::get_Property(BSTR bstrPropertyName, VA
     else if (MsRdpEx_StringEquals(propName, "VideoRecordingFrameRate")) {
         pValue->vt = VT_I4;
         pValue->intVal = (INT)m_VideoRecordingFrameRate;
+        hr = S_OK;
+    }
+    else if (MsRdpEx_StringEquals(propName, "VideoRecordingCursor")) {
+        pValue->vt = VT_BOOL;
+        pValue->boolVal = m_VideoRecordingCursor ? VARIANT_TRUE : VARIANT_FALSE;
         hr = S_OK;
     }
     else if (MsRdpEx_StringEquals(propName, "RecordingPath")) {
@@ -1464,6 +1486,12 @@ HRESULT CMsRdpExtendedSettings::ApplyRdpFile(void* rdpFilePtr)
                 pMsRdpExtendedSettings->put_Property(propName, &value);
             }
         }
+        else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 'i', "VideoRecordingCursor")) {
+            if (MsRdpEx_RdpFileEntry_GetVBoolValue(entry, &value)) {
+                bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
+                pMsRdpExtendedSettings->put_Property(propName, &value);
+            }
+        }
         else if (MsRdpEx_RdpFileEntry_IsMatch(entry, 's', "RecordingPath")) {
             bstr_t propName = _com_util::ConvertStringToBSTR(entry->name);
             bstr_t propValue = _com_util::ConvertStringToBSTR(entry->value);
@@ -1862,6 +1890,11 @@ uint32_t CMsRdpExtendedSettings::GetVideoRecordingQuality()
 uint32_t CMsRdpExtendedSettings::GetVideoRecordingFrameRate()
 {
     return m_VideoRecordingFrameRate;
+}
+
+bool CMsRdpExtendedSettings::GetVideoRecordingCursor()
+{
+    return m_VideoRecordingCursor;
 }
 
 char* CMsRdpExtendedSettings::GetRecordingPath()

--- a/include/MsRdpEx/RdpInstance.h
+++ b/include/MsRdpEx/RdpInstance.h
@@ -39,6 +39,10 @@ public:
     virtual void __stdcall SetLastMousePosition(int32_t posX, int32_t posY) = 0;
     virtual HRESULT __stdcall GetWTSPluginObject(LPVOID* ppvObject) = 0;
     virtual HRESULT __stdcall SetWTSPluginObject(LPVOID pvObject) = 0;
+    virtual void __stdcall SetCursor(HCURSOR cursor) = 0;
+    virtual void __stdcall UpdateCursorPosition(int32_t x, int32_t y) = 0;
+    virtual void __stdcall HideCursor() = 0;
+    virtual void __stdcall DumpFrameWithCursor() = 0;
 };
 
 class CMsRdpExInstance;

--- a/include/MsRdpEx/RdpSettings.h
+++ b/include/MsRdpEx/RdpSettings.h
@@ -70,6 +70,7 @@ public:
     bool GetVideoRecordingEnabled();
     uint32_t GetVideoRecordingQuality();
     uint32_t GetVideoRecordingFrameRate();
+    bool GetVideoRecordingCursor();
     char* GetRecordingPath();
     char* GetRecordingSessionId();
     char* GetRecordingPipeName();
@@ -102,6 +103,7 @@ private:
     bool m_VideoRecordingEnabled = false;
     uint32_t m_VideoRecordingQuality = 5;
     uint32_t m_VideoRecordingFrameRate = 0;
+    bool m_VideoRecordingCursor = false;
     char* m_RecordingPath = NULL;
     char* m_RecordingSessionId = NULL;
     char* m_RecordingPipeName = NULL;


### PR DESCRIPTION
MS RDP (the ActiveX/mstscax engine) recordings never showed the mouse cursor — same root cause as the NativeSessions fix (Devolutions/NativeSessions#163): the cursor's an OS overlay, so it never lands in the shadow bitmap we capture. Ticket: [RDMW-23239](https://devolutions.atlassian.net/browse/RDMW-23239).

So we draw it in. mstscax paints the remote cursor via `SetCursor`, so we grab the shape from `WM_SETCURSOR` + `WM_MOUSEMOVE`, track position off the window's own mouse messages, and composite it onto each recorded frame with save-under (draw → encode → restore) so the shared shadow bitmap stays clean — no trails. State is per-instance, so two sessions recording at once each get their own cursor. Frame-rate cap still respected (cadeau does the throttling).

Tested against the IT-HELP lab (RDP into IT-HELP-DC + IT-HELP-RDM), single and dual instance, windowed and fullscreen: cursor tracks, shape changes (arrow/hand/I-beam), no trails, no double cursor.


[RDMW-23239]: https://devolutions.atlassian.net/browse/RDMW-23239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ