### PR TITLE
Added Avalonia RdpClientView control and Avalonia test app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,33 @@ The generated assets deliberately do not provide legacy COM coclasses (such as `
 
 The legacy and generated assets define overlapping `MSTSCLib` type names and cannot be referenced by the same application. Select exactly one `MsRdpExComInterop` mode per project.
 
+### Avalonia RDP view
+
+Avalonia 12 applications can enable the reusable, bitmap-backed
+`Devolutions.MsRdpEx.Avalonia.RdpClientView` from the same NuGet package:
+
+```xml
+<PropertyGroup>
+  <MsRdpExAvalonia>true</MsRdpExAvalonia>
+</PropertyGroup>
+
+<ItemGroup>
+  <PackageReference Include="Avalonia" Version="12.1.1" />
+  <PackageReference Include="Devolutions.MsRdpEx" Version="..." />
+</ItemGroup>
+```
+
+`MsRdpExAvalonia=true` selects the generated COM projection and references the
+packaged `Devolutions.MsRdpEx.Avalonia.dll`. The consuming application keeps
+its normal Avalonia package references, so Avalonia is not imposed on existing
+WinForms or .NET Framework consumers. `RdpClientView` is an Avalonia
+`UserControl`; it renders the MsRdpEx shadow bitmap and does not use
+`NativeControlHost`, Windows Forms `AxHost`, or ATL hosting helpers. MsRdpEx
+directly provides the OLE client-site and in-place-site contract required by
+the ActiveX control, while the required HWND remains off-screen. Use
+`Connect(RdpConnectionSettings)` for the convenience API, or `GetClient<T>()`
+after `ClientReady` for direct generated MSTSCLib configuration.
+
 ## Extended .RDP File Options
 
 MsRdpEx processes additional .RDP file options that are not normally supported by mstsc.exe:

--- a/dll/AxHost/RdpAxHostWnd.cpp
+++ b/dll/AxHost/RdpAxHostWnd.cpp
@@ -98,12 +98,15 @@ public:
             SafeRelease(m_eventSink);
         }
 
+        if (m_pOleInPlaceSiteEx)
+            m_pOleInPlaceSiteEx->SetInPlaceObject(NULL);
+
         SafeRelease(m_pOleInPlaceActiveObject);
         SafeRelease(m_pOleObject);
         SafeRelease(m_rdpClient);
+        SafeRelease(m_pOleInPlaceObject);
         SafeRelease(m_pOleInPlaceSiteEx);
         SafeRelease(m_pOleClientSite);
-        SafeRelease(m_pOleInPlaceObject);
 
         return S_OK;
     }
@@ -390,6 +393,8 @@ public:
         if (FAILED(hr)) {
             return hr;
         }
+
+        m_pOleInPlaceSiteEx->SetInPlaceObject(m_pOleInPlaceObject);
 
         hr = m_pOleObject->SetClientSite(m_pOleClientSite);
 

--- a/dll/AxHost/RdpOleHost.cpp
+++ b/dll/AxHost/RdpOleHost.cpp
@@ -1,0 +1,370 @@
+#include <MsRdpEx/RdpOleHost.h>
+
+#include <new>
+#include <ocidl.h>
+
+#include "RdpComBase.h"
+#include "RdpOleSite.h"
+
+class CRdpOleHost : public IUnknown
+{
+public:
+    CRdpOleHost()
+        : m_refCount(1), m_hWnd(NULL), m_contained(false), m_clientSiteSet(false),
+          m_miscStatus(0),
+          m_pOleClientSite(NULL), m_pOleInPlaceSiteEx(NULL), m_pOleObject(NULL),
+          m_pOleInPlaceObject(NULL), m_pOleInPlaceActiveObject(NULL)
+    {
+        SetRectEmpty(&m_bounds);
+    }
+
+    STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
+    {
+        if (!ppv)
+            return E_POINTER;
+
+        *ppv = NULL;
+
+        if (riid == IID_IUnknown)
+        {
+            *ppv = static_cast<IUnknown*>(this);
+            AddRef();
+        }
+        else if ((riid == IID_IOleClientSite || riid == IID_IOleControlSite ||
+                  riid == IID_IParseDisplayName || riid == IID_IOleContainer ||
+                  riid == IID_IDispatch || riid == IID_ISimpleFrameSite ||
+                  riid == IID_IPropertyNotifySink) && m_pOleClientSite)
+        {
+            return m_pOleClientSite->QueryInterface(riid, ppv);
+        }
+        else if ((riid == IID_IOleWindow || riid == IID_IOleInPlaceSite ||
+                  riid == IID_IOleInPlaceSiteEx || riid == IID_IOleInPlaceUIWindow ||
+                  riid == IID_IOleInPlaceFrame) &&
+                 m_pOleInPlaceSiteEx)
+        {
+            return m_pOleInPlaceSiteEx->QueryInterface(riid, ppv);
+        }
+        else
+        {
+            return E_NOINTERFACE;
+        }
+
+        return S_OK;
+    }
+
+    STDMETHOD_(ULONG, AddRef)() override
+    {
+        return InterlockedIncrement(&m_refCount);
+    }
+
+    STDMETHOD_(ULONG, Release)() override
+    {
+        ULONG refCount = InterlockedDecrement(&m_refCount);
+        if (refCount == 0)
+            delete this;
+        return refCount;
+    }
+
+    HRESULT Attach(IUnknown* pControl, HWND hWnd, LPCRECT pBounds)
+    {
+        HRESULT hr = S_OK;
+        IPersistStreamInit* pPersistStreamInit = NULL;
+
+        if (!pControl || !hWnd || !IsWindow(hWnd))
+            return E_INVALIDARG;
+
+        if (!pBounds || pBounds->right <= pBounds->left || pBounds->bottom <= pBounds->top)
+            return E_INVALIDARG;
+
+        m_hWnd = hWnd;
+        m_bounds = *pBounds;
+
+        m_pOleClientSite = new (std::nothrow) CRdpOleClientSite(this);
+        m_pOleInPlaceSiteEx = new (std::nothrow) CRdpOleInPlaceSiteEx(this);
+        if (!m_pOleClientSite || !m_pOleInPlaceSiteEx)
+        {
+            hr = E_OUTOFMEMORY;
+            goto error;
+        }
+
+        m_pOleInPlaceSiteEx->SetWindow(hWnd);
+
+        hr = pControl->QueryInterface(IID_IOleObject, (void**)&m_pOleObject);
+        if (FAILED(hr))
+            goto error;
+
+        // The Microsoft RDP control advertises SETCLIENTSITEFIRST. Honor the
+        // control's actual misc-status contract rather than relying on its
+        // historical tolerance of the reverse initialization order.
+        hr = m_pOleObject->GetMiscStatus(DVASPECT_CONTENT, &m_miscStatus);
+        if (FAILED(hr))
+            m_miscStatus = 0;
+
+        if (m_miscStatus & OLEMISC_SETCLIENTSITEFIRST)
+        {
+            hr = m_pOleObject->SetClientSite(m_pOleClientSite);
+            if (FAILED(hr))
+                goto error;
+            m_clientSiteSet = true;
+        }
+
+        hr = pControl->QueryInterface(IID_IOleInPlaceObject, (void**)&m_pOleInPlaceObject);
+        if (FAILED(hr))
+            goto error;
+        m_pOleInPlaceSiteEx->SetInPlaceObject(m_pOleInPlaceObject);
+
+        hr = pControl->QueryInterface(IID_IOleInPlaceActiveObject, (void**)&m_pOleInPlaceActiveObject);
+        if (FAILED(hr))
+            goto error;
+
+        hr = pControl->QueryInterface(IID_IPersistStreamInit, (void**)&pPersistStreamInit);
+        if (SUCCEEDED(hr))
+        {
+            hr = pPersistStreamInit->InitNew();
+            SafeRelease(pPersistStreamInit);
+            if (hr == E_NOTIMPL)
+                hr = S_OK;
+            if (FAILED(hr))
+                goto error;
+        }
+        else if (hr == E_NOINTERFACE)
+        {
+            hr = S_OK;
+        }
+        else
+        {
+            goto error;
+        }
+
+        if (!m_clientSiteSet)
+        {
+            hr = m_pOleObject->SetClientSite(m_pOleClientSite);
+            if (FAILED(hr))
+                goto error;
+            m_clientSiteSet = true;
+        }
+
+        m_pOleObject->SetHostNames(L"MsRdpEx", L"RdpClientView");
+
+        hr = OleSetContainedObject(pControl, TRUE);
+        if (FAILED(hr))
+            goto error;
+        m_contained = true;
+
+        hr = m_pOleObject->DoVerb(
+            OLEIVERB_INPLACEACTIVATE,
+            NULL,
+            m_pOleClientSite,
+            0,
+            hWnd,
+            &m_bounds);
+        if (FAILED(hr))
+        {
+            hr = m_pOleObject->DoVerb(
+                OLEIVERB_PRIMARY,
+                NULL,
+                m_pOleClientSite,
+                0,
+                hWnd,
+                &m_bounds);
+        }
+        if (FAILED(hr))
+            goto error;
+
+        return SetBounds(pBounds);
+
+    error:
+        SafeRelease(pPersistStreamInit);
+        Detach();
+        return hr;
+    }
+
+    HRESULT SetBounds(LPCRECT pBounds)
+    {
+        if (!pBounds)
+            return E_POINTER;
+
+        if (pBounds->right <= pBounds->left || pBounds->bottom <= pBounds->top)
+            return E_INVALIDARG;
+
+        m_bounds = *pBounds;
+        if (!m_pOleInPlaceObject)
+            return OLE_E_NOT_INPLACEACTIVE;
+
+        if ((m_miscStatus & OLEMISC_RECOMPOSEONRESIZE) && m_pOleObject)
+        {
+            // Match AxHost's OLE HIMETRIC basis. The in-place rectangle is
+            // already in physical pixels; using the host HWND's monitor DPI
+            // here causes the control to apply DPI scaling a second time.
+            HDC hdc = GetDC(NULL);
+            const int dpiX = hdc ? GetDeviceCaps(hdc, LOGPIXELSX) : USER_DEFAULT_SCREEN_DPI;
+            const int dpiY = hdc ? GetDeviceCaps(hdc, LOGPIXELSY) : USER_DEFAULT_SCREEN_DPI;
+            if (hdc)
+                ReleaseDC(NULL, hdc);
+
+            SIZEL extent = {
+                MulDiv(pBounds->right - pBounds->left, 2540, dpiX),
+                MulDiv(pBounds->bottom - pBounds->top, 2540, dpiY)
+            };
+            HRESULT hr = m_pOleObject->SetExtent(DVASPECT_CONTENT, &extent);
+            if (FAILED(hr))
+                return hr;
+        }
+
+        return m_pOleInPlaceObject->SetObjectRects(&m_bounds, &m_bounds);
+    }
+
+    HRESULT SetActive(BOOL active)
+    {
+        if (!m_pOleInPlaceActiveObject || !m_pOleObject)
+            return OLE_E_NOT_INPLACEACTIVE;
+
+        if (active)
+        {
+            HRESULT hr = m_pOleObject->DoVerb(
+                OLEIVERB_UIACTIVATE, NULL, m_pOleClientSite, 0, m_hWnd, &m_bounds);
+            if (FAILED(hr))
+                return hr;
+        }
+
+        HRESULT frameHr = m_pOleInPlaceActiveObject->OnFrameWindowActivate(active);
+        HRESULT docHr = m_pOleInPlaceActiveObject->OnDocWindowActivate(active);
+
+        if (!active && m_pOleInPlaceObject)
+            m_pOleInPlaceObject->UIDeactivate();
+
+        return FAILED(frameHr) ? frameHr : docHr;
+    }
+
+    HRESULT TranslateAccelerator(LPMSG pMsg)
+    {
+        if (!pMsg)
+            return E_POINTER;
+        return m_pOleInPlaceActiveObject
+            ? m_pOleInPlaceActiveObject->TranslateAccelerator(pMsg)
+            : OLE_E_NOT_INPLACEACTIVE;
+    }
+
+    void Detach()
+    {
+        if (m_pOleInPlaceSiteEx)
+            m_pOleInPlaceSiteEx->SetInPlaceObject(NULL);
+
+        if (m_pOleInPlaceObject)
+        {
+            m_pOleInPlaceObject->UIDeactivate();
+            m_pOleInPlaceObject->InPlaceDeactivate();
+        }
+
+        if (m_pOleObject)
+        {
+            m_pOleObject->Close(OLECLOSE_NOSAVE);
+
+            if (m_contained)
+            {
+                OleSetContainedObject(m_pOleObject, FALSE);
+                m_contained = false;
+            }
+
+            if (m_clientSiteSet)
+            {
+                m_pOleObject->SetClientSite(NULL);
+                m_clientSiteSet = false;
+            }
+        }
+
+        SafeRelease(m_pOleInPlaceActiveObject);
+        SafeRelease(m_pOleInPlaceObject);
+        SafeRelease(m_pOleObject);
+        SafeRelease(m_pOleInPlaceSiteEx);
+        SafeRelease(m_pOleClientSite);
+
+        m_hWnd = NULL;
+        m_miscStatus = 0;
+        SetRectEmpty(&m_bounds);
+    }
+
+private:
+    ~CRdpOleHost() = default;
+
+    LONG m_refCount;
+    HWND m_hWnd;
+    RECT m_bounds;
+    bool m_contained;
+    bool m_clientSiteSet;
+    DWORD m_miscStatus;
+    CRdpOleClientSite* m_pOleClientSite;
+    CRdpOleInPlaceSiteEx* m_pOleInPlaceSiteEx;
+    IOleObject* m_pOleObject;
+    IOleInPlaceObject* m_pOleInPlaceObject;
+    IOleInPlaceActiveObject* m_pOleInPlaceActiveObject;
+};
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_Attach(
+    IUnknown* pControl,
+    HWND hWnd,
+    LPCRECT pBounds,
+    MsRdpEx_RdpOleHost** ppHost)
+{
+    if (!ppHost)
+        return E_POINTER;
+
+    *ppHost = NULL;
+
+    if (!pBounds)
+        return E_POINTER;
+
+    CRdpOleHost* pHost = new (std::nothrow) CRdpOleHost();
+    if (!pHost)
+        return E_OUTOFMEMORY;
+
+    HRESULT hr = pHost->Attach(pControl, hWnd, pBounds);
+    if (FAILED(hr))
+    {
+        pHost->Release();
+        return hr;
+    }
+
+    *ppHost = reinterpret_cast<MsRdpEx_RdpOleHost*>(pHost);
+    return S_OK;
+}
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetBounds(
+    MsRdpEx_RdpOleHost* pHost,
+    LPCRECT pBounds)
+{
+    if (!pHost)
+        return E_POINTER;
+
+    return reinterpret_cast<CRdpOleHost*>(pHost)->SetBounds(pBounds);
+}
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetActive(
+    MsRdpEx_RdpOleHost* pHost,
+    BOOL active)
+{
+    if (!pHost)
+        return E_POINTER;
+
+    return reinterpret_cast<CRdpOleHost*>(pHost)->SetActive(active);
+}
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_TranslateAccelerator(
+    MsRdpEx_RdpOleHost* pHost,
+    LPMSG pMsg)
+{
+    if (!pHost)
+        return E_POINTER;
+
+    return reinterpret_cast<CRdpOleHost*>(pHost)->TranslateAccelerator(pMsg);
+}
+
+void STDAPICALLTYPE MsRdpEx_RdpOleHost_Release(MsRdpEx_RdpOleHost* pHost)
+{
+    if (!pHost)
+        return;
+
+    CRdpOleHost* pOleHost = reinterpret_cast<CRdpOleHost*>(pHost);
+    pOleHost->Detach();
+    pOleHost->Release();
+}

--- a/dll/AxHost/RdpOleSite.cpp
+++ b/dll/AxHost/RdpOleSite.cpp
@@ -23,11 +23,29 @@ STDMETHODIMP CRdpOleClientSite::QueryInterface(REFIID riid, void** ppv)
 
     *ppv = NULL;
 
-    if (riid == IID_IUnknown) {
-        *ppv = static_cast<IUnknown*>(this);
+    // All site tear-offs must expose the outer host as their controlling
+    // IUnknown. Returning a different IUnknown from each site violates COM
+    // identity and confuses controls that cache more than one site interface.
+    if (riid == IID_IUnknown && m_pUnkOuter) {
+        return m_pUnkOuter->QueryInterface(riid, ppv);
     }
     else if (riid == IID_IOleClientSite) {
         *ppv = static_cast<IOleClientSite*>(this);
+    }
+    else if (riid == IID_IOleControlSite) {
+        *ppv = static_cast<IOleControlSite*>(this);
+    }
+    else if (riid == IID_IParseDisplayName || riid == IID_IOleContainer) {
+        *ppv = static_cast<IOleContainer*>(this);
+    }
+    else if (riid == IID_IDispatch) {
+        *ppv = static_cast<IDispatch*>(this);
+    }
+    else if (riid == IID_ISimpleFrameSite) {
+        *ppv = static_cast<ISimpleFrameSite*>(this);
+    }
+    else if (riid == IID_IPropertyNotifySink) {
+        *ppv = static_cast<IPropertyNotifySink*>(this);
     }
     else if (m_pUnkOuter) {
         return m_pUnkOuter->QueryInterface(riid, ppv);
@@ -60,19 +78,29 @@ STDMETHODIMP_(ULONG) CRdpOleClientSite::Release()
 // IOleClientSite methods
 STDMETHODIMP CRdpOleClientSite::SaveObject()
 {
-    return S_OK;
+    return E_NOTIMPL;
 }
 
 STDMETHODIMP CRdpOleClientSite::GetMoniker(DWORD dwAssign, DWORD dwWhichMoniker, IMoniker** ppmk)
 {
+    UNREFERENCED_PARAMETER(dwAssign);
+    UNREFERENCED_PARAMETER(dwWhichMoniker);
+
+    if (!ppmk)
+        return E_POINTER;
+
     *ppmk = NULL;
     return E_NOTIMPL;
 }
 
 STDMETHODIMP CRdpOleClientSite::GetContainer(IOleContainer** ppContainer)
 {
-    *ppContainer = NULL;
-    return E_NOTIMPL;
+    if (!ppContainer)
+        return E_POINTER;
+
+    *ppContainer = static_cast<IOleContainer*>(this);
+    AddRef();
+    return S_OK;
 }
 
 STDMETHODIMP CRdpOleClientSite::ShowObject()
@@ -82,6 +110,7 @@ STDMETHODIMP CRdpOleClientSite::ShowObject()
 
 STDMETHODIMP CRdpOleClientSite::OnShowWindow(BOOL fShow)
 {
+    UNREFERENCED_PARAMETER(fShow);
     return S_OK;
 }
 
@@ -90,8 +119,277 @@ STDMETHODIMP CRdpOleClientSite::RequestNewObjectLayout()
     return E_NOTIMPL;
 }
 
+// IParseDisplayName / IOleContainer methods
+STDMETHODIMP CRdpOleClientSite::ParseDisplayName(
+    IBindCtx* pbc, LPOLESTR pszDisplayName, ULONG* pchEaten, IMoniker** ppmkOut)
+{
+    UNREFERENCED_PARAMETER(pbc);
+    UNREFERENCED_PARAMETER(pszDisplayName);
+    if (!pchEaten || !ppmkOut)
+        return E_POINTER;
+    *pchEaten = 0;
+    *ppmkOut = NULL;
+    return E_NOTIMPL;
+}
+
+STDMETHODIMP CRdpOleClientSite::EnumObjects(DWORD grfFlags, IEnumUnknown** ppenum)
+{
+    UNREFERENCED_PARAMETER(grfFlags);
+    if (!ppenum)
+        return E_POINTER;
+    *ppenum = NULL;
+    return E_NOTIMPL;
+}
+
+STDMETHODIMP CRdpOleClientSite::LockContainer(BOOL fLock)
+{
+    UNREFERENCED_PARAMETER(fLock);
+    return S_OK;
+}
+
+// IOleControlSite methods
+STDMETHODIMP CRdpOleClientSite::OnControlInfoChanged()
+{
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleClientSite::LockInPlaceActive(BOOL fLock)
+{
+    UNREFERENCED_PARAMETER(fLock);
+    return E_NOTIMPL;
+}
+
+STDMETHODIMP CRdpOleClientSite::GetExtendedControl(IDispatch** ppDisp)
+{
+    if (!ppDisp)
+        return E_POINTER;
+
+    *ppDisp = NULL;
+    return E_NOTIMPL;
+}
+
+static HRESULT RdpOleGetLogPixels(IUnknown* pUnkOuter, int* pLogPixelsX, int* pLogPixelsY)
+{
+    UNREFERENCED_PARAMETER(pUnkOuter);
+
+    if (!pLogPixelsX || !pLogPixelsY)
+        return E_POINTER;
+
+    *pLogPixelsX = USER_DEFAULT_SCREEN_DPI;
+    *pLogPixelsY = USER_DEFAULT_SCREEN_DPI;
+
+    // OLE HIMETRIC conversion uses the screen/logical coordinate basis. Using
+    // the hidden host HWND's per-monitor DPI double-scales the RDP child in a
+    // PerMonitorV2 process (for example, 640 becomes 426 at 150% scaling).
+    HDC hdc = GetDC(NULL);
+    if (!hdc)
+        return E_FAIL;
+
+    *pLogPixelsX = GetDeviceCaps(hdc, LOGPIXELSX);
+    *pLogPixelsY = GetDeviceCaps(hdc, LOGPIXELSY);
+    ReleaseDC(NULL, hdc);
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleClientSite::TransformCoords(
+    POINTL* pPtlHimetric, POINTF* pPtfContainer, DWORD dwFlags)
+{
+    if (!pPtlHimetric || !pPtfContainer)
+        return E_INVALIDARG;
+
+    const DWORD direction = dwFlags & (XFORMCOORDS_HIMETRICTOCONTAINER | XFORMCOORDS_CONTAINERTOHIMETRIC);
+    const DWORD kind = dwFlags & (XFORMCOORDS_POSITION | XFORMCOORDS_SIZE);
+    if ((direction != XFORMCOORDS_HIMETRICTOCONTAINER &&
+         direction != XFORMCOORDS_CONTAINERTOHIMETRIC) ||
+        (kind != XFORMCOORDS_POSITION && kind != XFORMCOORDS_SIZE))
+    {
+        return E_INVALIDARG;
+    }
+
+    int logPixelsX = USER_DEFAULT_SCREEN_DPI;
+    int logPixelsY = USER_DEFAULT_SCREEN_DPI;
+    RdpOleGetLogPixels(m_pUnkOuter, &logPixelsX, &logPixelsY);
+
+    if (direction == XFORMCOORDS_HIMETRICTOCONTAINER)
+    {
+        pPtfContainer->x = (FLOAT)MulDiv(pPtlHimetric->x, logPixelsX, 2540);
+        pPtfContainer->y = (FLOAT)MulDiv(pPtlHimetric->y, logPixelsY, 2540);
+    }
+    else
+    {
+        pPtlHimetric->x = MulDiv((LONG)pPtfContainer->x, 2540, logPixelsX);
+        pPtlHimetric->y = MulDiv((LONG)pPtfContainer->y, 2540, logPixelsY);
+    }
+
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleClientSite::TranslateAccelerator(LPMSG pMsg, DWORD grfModifiers)
+{
+    UNREFERENCED_PARAMETER(grfModifiers);
+    return pMsg ? S_FALSE : E_POINTER;
+}
+
+STDMETHODIMP CRdpOleClientSite::OnFocus(BOOL fGotFocus)
+{
+    UNREFERENCED_PARAMETER(fGotFocus);
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleClientSite::ShowPropertyFrame()
+{
+    return E_NOTIMPL;
+}
+
+// IDispatch ambient properties
+STDMETHODIMP CRdpOleClientSite::GetTypeInfoCount(UINT* pctinfo)
+{
+    if (!pctinfo)
+        return E_POINTER;
+
+    *pctinfo = 0;
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleClientSite::GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo** ppTInfo)
+{
+    UNREFERENCED_PARAMETER(iTInfo);
+    UNREFERENCED_PARAMETER(lcid);
+
+    if (!ppTInfo)
+        return E_POINTER;
+
+    *ppTInfo = NULL;
+    return E_NOTIMPL;
+}
+
+STDMETHODIMP CRdpOleClientSite::GetIDsOfNames(
+    REFIID riid, LPOLESTR* rgszNames, UINT cNames, LCID lcid, DISPID* rgDispId)
+{
+    UNREFERENCED_PARAMETER(riid);
+    UNREFERENCED_PARAMETER(rgszNames);
+    UNREFERENCED_PARAMETER(cNames);
+    UNREFERENCED_PARAMETER(lcid);
+
+    if (rgDispId)
+        *rgDispId = DISPID_UNKNOWN;
+    return DISP_E_UNKNOWNNAME;
+}
+
+STDMETHODIMP CRdpOleClientSite::Invoke(
+    DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
+    DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo,
+    UINT* puArgErr)
+{
+    UNREFERENCED_PARAMETER(riid);
+    UNREFERENCED_PARAMETER(lcid);
+    UNREFERENCED_PARAMETER(pDispParams);
+    UNREFERENCED_PARAMETER(pExcepInfo);
+    UNREFERENCED_PARAMETER(puArgErr);
+
+    if (!pVarResult)
+        return E_POINTER;
+    if (!(wFlags & DISPATCH_PROPERTYGET))
+        return DISP_E_MEMBERNOTFOUND;
+
+    VariantInit(pVarResult);
+
+    switch (dispIdMember)
+    {
+        case DISPID_AMBIENT_USERMODE:
+        case DISPID_AMBIENT_MESSAGEREFLECT:
+        case DISPID_AMBIENT_SUPPORTSMNEMONICS:
+        case DISPID_AMBIENT_AUTOCLIP:
+            V_VT(pVarResult) = VT_BOOL;
+            V_BOOL(pVarResult) = VARIANT_TRUE;
+            return S_OK;
+
+        case DISPID_AMBIENT_UIDEAD:
+        case DISPID_AMBIENT_SHOWGRABHANDLES:
+        case DISPID_AMBIENT_SHOWHATCHING:
+        case DISPID_AMBIENT_DISPLAYASDEFAULT:
+            V_VT(pVarResult) = VT_BOOL;
+            V_BOOL(pVarResult) = VARIANT_FALSE;
+            return S_OK;
+
+        case DISPID_AMBIENT_LOCALEID:
+            V_VT(pVarResult) = VT_I4;
+            V_I4(pVarResult) = (LONG)GetThreadLocale();
+            return S_OK;
+
+        case DISPID_AMBIENT_BACKCOLOR:
+            V_VT(pVarResult) = VT_I4;
+            V_I4(pVarResult) = (LONG)GetSysColor(COLOR_WINDOW);
+            return S_OK;
+
+        case DISPID_AMBIENT_FORECOLOR:
+            V_VT(pVarResult) = VT_I4;
+            V_I4(pVarResult) = (LONG)GetSysColor(COLOR_WINDOWTEXT);
+            return S_OK;
+
+        case DISPID_AMBIENT_DISPLAYNAME:
+            V_VT(pVarResult) = VT_BSTR;
+            V_BSTR(pVarResult) = SysAllocString(L"RdpClientView");
+            return V_BSTR(pVarResult) ? S_OK : E_OUTOFMEMORY;
+
+        case DISPID_AMBIENT_APPEARANCE:
+            V_VT(pVarResult) = VT_I2;
+            V_I2(pVarResult) = 0;
+            return S_OK;
+
+        default:
+            return DISP_E_MEMBERNOTFOUND;
+    }
+}
+
+// ISimpleFrameSite methods
+STDMETHODIMP CRdpOleClientSite::PreMessageFilter(
+    HWND hWnd, UINT msg, WPARAM wp, LPARAM lp, LRESULT* plResult, DWORD* pdwCookie)
+{
+    UNREFERENCED_PARAMETER(hWnd);
+    UNREFERENCED_PARAMETER(msg);
+    UNREFERENCED_PARAMETER(wp);
+    UNREFERENCED_PARAMETER(lp);
+
+    if (!plResult || !pdwCookie)
+        return E_POINTER;
+
+    *plResult = 0;
+    *pdwCookie = 0;
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleClientSite::PostMessageFilter(
+    HWND hWnd, UINT msg, WPARAM wp, LPARAM lp, LRESULT* plResult, DWORD dwCookie)
+{
+    UNREFERENCED_PARAMETER(hWnd);
+    UNREFERENCED_PARAMETER(msg);
+    UNREFERENCED_PARAMETER(wp);
+    UNREFERENCED_PARAMETER(lp);
+    UNREFERENCED_PARAMETER(dwCookie);
+
+    if (!plResult)
+        return E_POINTER;
+
+    *plResult = 0;
+    return S_FALSE;
+}
+
+// IPropertyNotifySink methods
+STDMETHODIMP CRdpOleClientSite::OnChanged(DISPID dispID)
+{
+    UNREFERENCED_PARAMETER(dispID);
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleClientSite::OnRequestEdit(DISPID dispID)
+{
+    UNREFERENCED_PARAMETER(dispID);
+    return S_OK;
+}
+
 CRdpOleInPlaceSiteEx::CRdpOleInPlaceSiteEx(IUnknown* pUnkOuter)
-    : m_refCount(1), m_hWnd(0)
+    : m_refCount(1), m_hWnd(0), m_pOleInPlaceObject(NULL)
 {
     m_pUnkOuter = pUnkOuter;
     m_pUnkOuter->AddRef();
@@ -99,6 +397,7 @@ CRdpOleInPlaceSiteEx::CRdpOleInPlaceSiteEx(IUnknown* pUnkOuter)
 
 CRdpOleInPlaceSiteEx::~CRdpOleInPlaceSiteEx()
 {
+    m_pOleInPlaceObject = NULL;
     SafeRelease(m_pUnkOuter);
 }
 
@@ -110,11 +409,14 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::QueryInterface(REFIID riid, void** ppv)
     if (!ppv) return E_INVALIDARG;
     *ppv = NULL;
 
-    if (riid == IID_IUnknown) {
-        *ppv = static_cast<IUnknown*>(this);
+    if (riid == IID_IUnknown && m_pUnkOuter) {
+        return m_pUnkOuter->QueryInterface(riid, ppv);
     }
     else if (riid == IID_IOleWindow || riid == IID_IOleInPlaceSite || riid == IID_IOleInPlaceSiteEx) {
         *ppv = static_cast<IOleInPlaceSiteEx*>(this);
+    }
+    else if (riid == IID_IOleInPlaceUIWindow || riid == IID_IOleInPlaceFrame) {
+        *ppv = static_cast<IOleInPlaceFrame*>(this);
     }
     else if (m_pUnkOuter) {
         return m_pUnkOuter->QueryInterface(riid, ppv);
@@ -147,13 +449,17 @@ STDMETHODIMP_(ULONG) CRdpOleInPlaceSiteEx::Release()
 // IOleWindow methods
 STDMETHODIMP CRdpOleInPlaceSiteEx::GetWindow(HWND* phwnd)
 {
+    if (!phwnd)
+        return E_POINTER;
+
     *phwnd = m_hWnd;
-    return S_OK;
+    return m_hWnd ? S_OK : E_FAIL;
 }
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::ContextSensitiveHelp(BOOL fEnterMode)
 {
-    return S_OK;
+    UNREFERENCED_PARAMETER(fEnterMode);
+    return E_NOTIMPL;
 }
 
 // IOleInPlaceSite methods
@@ -178,28 +484,44 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::GetWindowContext(IOleInPlaceFrame** ppFrame, 
 {
     RECT rect;
 
+    if (!ppFrame || !ppDoc || !lprcPosRect || !lprcClipRect)
+        return E_POINTER;
+
     *ppFrame = NULL;
     *ppDoc = NULL;
-    lpFrameInfo = NULL;
 
-    if (GetClientRect(m_hWnd, &rect))
+    if (lpFrameInfo)
     {
-        int width = rect.right - rect.left;
-        int height = rect.bottom - rect.top;
-        SetRect(lprcClipRect, 0, 0, width, height);
-        SetRect(lprcPosRect, 0, 0, width, height);
+        lpFrameInfo->cb = sizeof(OLEINPLACEFRAMEINFO);
+        lpFrameInfo->fMDIApp = FALSE;
+        lpFrameInfo->hwndFrame = m_hWnd;
+        lpFrameInfo->haccel = NULL;
+        lpFrameInfo->cAccelEntries = 0;
     }
+
+    if (!m_hWnd || !GetClientRect(m_hWnd, &rect))
+        return E_FAIL;
+
+    *ppFrame = static_cast<IOleInPlaceFrame*>(this);
+    AddRef();
+
+    int width = rect.right - rect.left;
+    int height = rect.bottom - rect.top;
+    SetRect(lprcClipRect, 0, 0, width, height);
+    SetRect(lprcPosRect, 0, 0, width, height);
 
     return S_OK;
 }
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::Scroll(SIZE scrollExtant)
 {
-    return S_OK;
+    UNREFERENCED_PARAMETER(scrollExtant);
+    return S_FALSE;
 }
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::OnUIDeactivate(BOOL fUndoable)
 {
+    UNREFERENCED_PARAMETER(fUndoable);
     return S_OK;
 }
 
@@ -215,23 +537,31 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::DiscardUndoState()
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::DeactivateAndUndo()
 {
-    return S_OK;
+    return m_pOleInPlaceObject ? m_pOleInPlaceObject->UIDeactivate() : OLE_E_NOT_INPLACEACTIVE;
 }
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::OnPosRectChange(LPCRECT lprcPosRect)
 {
-    return S_OK;
+    if (!lprcPosRect)
+        return E_POINTER;
+    return m_pOleInPlaceObject
+        ? m_pOleInPlaceObject->SetObjectRects(lprcPosRect, lprcPosRect)
+        : OLE_E_NOT_INPLACEACTIVE;
 }
 
 // IOleInPlaceSiteEx methods
 STDMETHODIMP CRdpOleInPlaceSiteEx::OnInPlaceActivateEx(BOOL* pfNoRedraw, DWORD dwFlags)
 {
-    *pfNoRedraw = TRUE;
+    UNREFERENCED_PARAMETER(dwFlags);
+
+    if (pfNoRedraw)
+        *pfNoRedraw = FALSE;
     return S_OK;
 }
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::OnInPlaceDeactivateEx(BOOL fNoRedraw)
 {
+    UNREFERENCED_PARAMETER(fNoRedraw);
     return S_OK;
 }
 
@@ -245,4 +575,83 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::SetWindow(HWND hWnd)
 {
     m_hWnd = hWnd;
     return S_OK;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::SetInPlaceObject(IOleInPlaceObject* pOleInPlaceObject)
+{
+    m_pOleInPlaceObject = pOleInPlaceObject;
+    return S_OK;
+}
+
+// IOleInPlaceUIWindow methods
+STDMETHODIMP CRdpOleInPlaceSiteEx::GetBorder(LPRECT lprectBorder)
+{
+    if (!lprectBorder)
+        return E_POINTER;
+    if (!m_hWnd || !GetClientRect(m_hWnd, lprectBorder))
+        return E_FAIL;
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::RequestBorderSpace(LPCBORDERWIDTHS pborderwidths)
+{
+    UNREFERENCED_PARAMETER(pborderwidths);
+    return INPLACE_E_NOTOOLSPACE;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::SetBorderSpace(LPCBORDERWIDTHS pborderwidths)
+{
+    UNREFERENCED_PARAMETER(pborderwidths);
+    return INPLACE_E_NOTOOLSPACE;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::SetActiveObject(
+    IOleInPlaceActiveObject* pActiveObject, LPCOLESTR pszObjName)
+{
+    UNREFERENCED_PARAMETER(pActiveObject);
+    UNREFERENCED_PARAMETER(pszObjName);
+    return S_OK;
+}
+
+// IOleInPlaceFrame methods. This host deliberately supplies no merged menus or
+// tool space, but it must provide a real frame identity for OLE activation.
+STDMETHODIMP CRdpOleInPlaceSiteEx::InsertMenus(
+    HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths)
+{
+    UNREFERENCED_PARAMETER(hmenuShared);
+    UNREFERENCED_PARAMETER(lpMenuWidths);
+    return E_NOTIMPL;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::SetMenu(
+    HMENU hmenuShared, HOLEMENU holemenu, HWND hwndActiveObject)
+{
+    UNREFERENCED_PARAMETER(hmenuShared);
+    UNREFERENCED_PARAMETER(holemenu);
+    UNREFERENCED_PARAMETER(hwndActiveObject);
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::RemoveMenus(HMENU hmenuShared)
+{
+    UNREFERENCED_PARAMETER(hmenuShared);
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::SetStatusText(LPCOLESTR pszStatusText)
+{
+    UNREFERENCED_PARAMETER(pszStatusText);
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::EnableModeless(BOOL fEnable)
+{
+    UNREFERENCED_PARAMETER(fEnable);
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::TranslateAccelerator(LPMSG lpmsg, WORD wID)
+{
+    UNREFERENCED_PARAMETER(wID);
+    return lpmsg ? S_FALSE : E_POINTER;
 }

--- a/dll/AxHost/RdpOleSite.h
+++ b/dll/AxHost/RdpOleSite.h
@@ -5,7 +5,13 @@
 
 #include "RdpComBase.h"
 
-class CRdpOleClientSite : public IOleClientSite {
+class CRdpOleClientSite :
+    public IOleClientSite,
+    public IOleControlSite,
+    public IOleContainer,
+    public IDispatch,
+    public ISimpleFrameSite,
+    public IPropertyNotifySink {
 public:
     // Constructor and Destructor
     CRdpOleClientSite(IUnknown* pUnkOuter);
@@ -24,12 +30,46 @@ public:
     STDMETHOD(OnShowWindow)(BOOL fShow) override;
     STDMETHOD(RequestNewObjectLayout)() override;
 
+    // IParseDisplayName / IOleContainer methods
+    STDMETHOD(ParseDisplayName)(IBindCtx* pbc, LPOLESTR pszDisplayName,
+        ULONG* pchEaten, IMoniker** ppmkOut) override;
+    STDMETHOD(EnumObjects)(DWORD grfFlags, IEnumUnknown** ppenum) override;
+    STDMETHOD(LockContainer)(BOOL fLock) override;
+
+    // IOleControlSite methods
+    STDMETHOD(OnControlInfoChanged)() override;
+    STDMETHOD(LockInPlaceActive)(BOOL fLock) override;
+    STDMETHOD(GetExtendedControl)(IDispatch** ppDisp) override;
+    STDMETHOD(TransformCoords)(POINTL* pPtlHimetric, POINTF* pPtfContainer, DWORD dwFlags) override;
+    STDMETHOD(TranslateAccelerator)(LPMSG pMsg, DWORD grfModifiers) override;
+    STDMETHOD(OnFocus)(BOOL fGotFocus) override;
+    STDMETHOD(ShowPropertyFrame)() override;
+
+    // IDispatch methods (ambient container properties)
+    STDMETHOD(GetTypeInfoCount)(UINT* pctinfo) override;
+    STDMETHOD(GetTypeInfo)(UINT iTInfo, LCID lcid, ITypeInfo** ppTInfo) override;
+    STDMETHOD(GetIDsOfNames)(REFIID riid, LPOLESTR* rgszNames, UINT cNames,
+        LCID lcid, DISPID* rgDispId) override;
+    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
+        DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo,
+        UINT* puArgErr) override;
+
+    // ISimpleFrameSite methods
+    STDMETHOD(PreMessageFilter)(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp,
+        LRESULT* plResult, DWORD* pdwCookie) override;
+    STDMETHOD(PostMessageFilter)(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp,
+        LRESULT* plResult, DWORD dwCookie) override;
+
+    // IPropertyNotifySink methods
+    STDMETHOD(OnChanged)(DISPID dispID) override;
+    STDMETHOD(OnRequestEdit)(DISPID dispID) override;
+
 private:
     ULONG m_refCount;
     IUnknown* m_pUnkOuter;
 };
 
-class CRdpOleInPlaceSiteEx : public IOleInPlaceSiteEx {
+class CRdpOleInPlaceSiteEx : public IOleInPlaceSiteEx, public IOleInPlaceFrame {
 public:
     // Constructor and Destructor
     CRdpOleInPlaceSiteEx(IUnknown* pUnkOuter);
@@ -64,12 +104,28 @@ public:
     STDMETHOD(OnInPlaceDeactivateEx)(BOOL fNoRedraw) override;
     STDMETHOD(RequestUIActivate)() override;
 
+    // IOleInPlaceUIWindow methods
+    STDMETHOD(GetBorder)(LPRECT lprectBorder) override;
+    STDMETHOD(RequestBorderSpace)(LPCBORDERWIDTHS pborderwidths) override;
+    STDMETHOD(SetBorderSpace)(LPCBORDERWIDTHS pborderwidths) override;
+    STDMETHOD(SetActiveObject)(IOleInPlaceActiveObject* pActiveObject, LPCOLESTR pszObjName) override;
+
+    // IOleInPlaceFrame methods
+    STDMETHOD(InsertMenus)(HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths) override;
+    STDMETHOD(SetMenu)(HMENU hmenuShared, HOLEMENU holemenu, HWND hwndActiveObject) override;
+    STDMETHOD(RemoveMenus)(HMENU hmenuShared) override;
+    STDMETHOD(SetStatusText)(LPCOLESTR pszStatusText) override;
+    STDMETHOD(EnableModeless)(BOOL fEnable) override;
+    STDMETHOD(TranslateAccelerator)(LPMSG lpmsg, WORD wID) override;
+
     // Additional methods specific to your implementation
     STDMETHOD(SetWindow)(HWND hWnd);
+    STDMETHOD(SetInPlaceObject)(IOleInPlaceObject* pOleInPlaceObject);
 
 private:
     ULONG m_refCount;
     HWND m_hWnd;
+    IOleInPlaceObject* m_pOleInPlaceObject; // weak; owned by the outer host
     IUnknown* m_pUnkOuter;
 };
 

--- a/dll/CMakeLists.txt
+++ b/dll/CMakeLists.txt
@@ -30,6 +30,7 @@ set(MSRDPEX_HEADERS
     "${MSRDPEX_INCLUDE_DIR}/RdpCoreApi.h"
     "${MSRDPEX_INCLUDE_DIR}/RdpProcess.h"
     "${MSRDPEX_INCLUDE_DIR}/RdpInstance.h"
+    "${MSRDPEX_INCLUDE_DIR}/RdpOleHost.h"
     "${MSRDPEX_INCLUDE_DIR}/RdpSettings.h"
     "${MSRDPEX_INCLUDE_DIR}/OutputMirror.h"
     "${MSRDPEX_INCLUDE_DIR}/VideoRecorder.h"
@@ -90,6 +91,7 @@ set(MSRDPEX_AXHOST_SOURCES
     "${MSRDPEX_AXHOST_SOURCE_DIR}/RdpEventSink.h"
     "${MSRDPEX_AXHOST_SOURCE_DIR}/RdpOleSite.cpp"
     "${MSRDPEX_AXHOST_SOURCE_DIR}/RdpOleSite.h"
+    "${MSRDPEX_AXHOST_SOURCE_DIR}/RdpOleHost.cpp"
     "${MSRDPEX_AXHOST_SOURCE_DIR}/RdpComBase.h"
     "${MSRDPEX_AXHOST_SOURCE_DIR}/RdpWinMain.cpp"
     "${MSRDPEX_AXHOST_SOURCE_DIR}/RdpWinMain.h")
@@ -112,7 +114,8 @@ set(MSRDPEX_LIBS
     credui.lib
     advapi32.lib
     crypt32.lib
-    comctl32.lib)
+    comctl32.lib
+    ole32.lib)
 
 target_compile_options(MsRdpEx_Dll PRIVATE /W4)
 

--- a/dll/MsRdpEx.def
+++ b/dll/MsRdpEx.def
@@ -26,3 +26,9 @@ EXPORTS
     MsRdpEx_GetArgumentVector
     MsRdpEx_FreeArgumentVector
     MsRdpEx_WinMain
+    MsRdpEx_RdpOleHost_Attach
+    MsRdpEx_RdpOleHost_SetBounds
+    MsRdpEx_RdpOleHost_SetActive
+    MsRdpEx_RdpOleHost_TranslateAccelerator
+    MsRdpEx_RdpOleHost_Release
+    MsRdpEx_OutputMirror_GetFrameVersion

--- a/dll/MsRdpEx.def
+++ b/dll/MsRdpEx.def
@@ -32,3 +32,9 @@ EXPORTS
     MsRdpEx_RdpOleHost_TranslateAccelerator
     MsRdpEx_RdpOleHost_Release
     MsRdpEx_OutputMirror_GetFrameVersion
+    MsRdpEx_OutputMirrorCapture_Create
+    MsRdpEx_OutputMirrorCapture_GetFrameVersion
+    MsRdpEx_OutputMirrorCapture_GetShadowBitmap
+    MsRdpEx_OutputMirrorCapture_Lock
+    MsRdpEx_OutputMirrorCapture_Unlock
+    MsRdpEx_OutputMirrorCapture_Release

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -19,7 +19,7 @@ struct _MsRdpEx_OutputMirror
 	HDC hShadowDC;
 	HBITMAP hShadowBitmap;
 	HGDIOBJ hShadowObject;
-	uint32_t captureIndex;
+	volatile LONG captureIndex;
 	uint64_t captureBaseTime;
 	int64_t startTime;
 	int videoRecordingCount;
@@ -77,6 +77,14 @@ void MsRdpEx_OutputMirror_GetFrameSize(MsRdpEx_OutputMirror* ctx, uint32_t* fram
 	*frameHeight = ctx->bitmapHeight;
 }
 
+uint32_t MsRdpEx_OutputMirror_GetFrameVersion(MsRdpEx_OutputMirror* ctx)
+{
+	if (!ctx)
+		return 0;
+
+	return (uint32_t)InterlockedCompareExchange(&ctx->captureIndex, 0, 0);
+}
+
 bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx)
 {
 	uint64_t captureTime;
@@ -104,7 +112,7 @@ bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx)
 		fwrite(metadata, 1, strlen(metadata), ctx->frameMetadataFile);
 	}
 
-	ctx->captureIndex++;
+	InterlockedIncrement(&ctx->captureIndex);
 	return true;
 }
 

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -1,6 +1,8 @@
 
 #include <MsRdpEx/RdpInstance.h>
 
+#include <new>
+
 #include <MsRdpEx/Memory.h>
 #include <MsRdpEx/ArrayList.h>
 #include <MsRdpEx/Environment.h>
@@ -34,9 +36,10 @@ public:
             m_CursorOverlay = NULL;
         }
 
-        if (m_OutputMirror) {
-            MsRdpEx_OutputMirror_Free(m_OutputMirror);
-            m_OutputMirror = NULL;
+        MsRdpEx_OutputMirror* outputMirror = (MsRdpEx_OutputMirror*)
+            InterlockedExchangePointer((PVOID*)&m_OutputMirror, NULL);
+        if (outputMirror) {
+            MsRdpEx_OutputMirror_Free(outputMirror);
         }
 
         if (m_pMsRdpExtendedSettings) {
@@ -119,13 +122,13 @@ public:
 
     HRESULT STDMETHODCALLTYPE GetOutputMirrorObject(LPVOID* ppvObject)
     {
-        *ppvObject = m_OutputMirror;
+        *ppvObject = GetOutputMirror();
         return S_OK;
     }
 
     HRESULT STDMETHODCALLTYPE SetOutputMirrorObject(LPVOID pvObject)
     {
-        m_OutputMirror = (MsRdpEx_OutputMirror*) pvObject;
+        InterlockedExchangePointer((PVOID*)&m_OutputMirror, pvObject);
         return S_OK;
     }
 
@@ -259,7 +262,7 @@ public:
     bool STDMETHODCALLTYPE GetShadowBitmap(HDC* phDC, HBITMAP* phBitmap, uint8_t** pBitmapData,
         uint32_t* pBitmapWidth, uint32_t* pBitmapHeight, uint32_t* pBitmapStep)
     {
-        MsRdpEx_OutputMirror* outputMirror = m_OutputMirror;
+        MsRdpEx_OutputMirror* outputMirror = GetOutputMirror();
 
         if (!outputMirror)
             return false;
@@ -270,7 +273,7 @@ public:
 
     void STDMETHODCALLTYPE LockShadowBitmap()
     {
-        MsRdpEx_OutputMirror* outputMirror = m_OutputMirror;
+        MsRdpEx_OutputMirror* outputMirror = GetOutputMirror();
 
         if (!outputMirror)
             return;
@@ -285,7 +288,7 @@ public:
 
     void STDMETHODCALLTYPE UnlockShadowBitmap()
     {
-        MsRdpEx_OutputMirror* outputMirror = m_OutputMirror;
+        MsRdpEx_OutputMirror* outputMirror = GetOutputMirror();
 
         if (!outputMirror)
             return;
@@ -340,18 +343,25 @@ public:
 
     void STDMETHODCALLTYPE DumpFrameWithCursor()
     {
-        if (!m_OutputMirror)
+        MsRdpEx_OutputMirror* outputMirror = GetOutputMirror();
+        if (!outputMirror)
             return;
 
         if (m_CursorOverlay && IsCursorOverlayEnabled())
             MsRdpEx_CursorOverlay_DumpFrame(
-                m_CursorOverlay, m_OutputMirror,
+                m_CursorOverlay, outputMirror,
                 m_hInputCaptureWnd, m_hOutputPresenterWnd);
         else
-            MsRdpEx_OutputMirror_DumpFrame(m_OutputMirror);
+            MsRdpEx_OutputMirror_DumpFrame(outputMirror);
     }
 
 private:
+    MsRdpEx_OutputMirror* GetOutputMirror()
+    {
+        return (MsRdpEx_OutputMirror*)InterlockedCompareExchangePointer(
+            (PVOID*)&m_OutputMirror, NULL, NULL);
+    }
+
     bool IsCursorOverlayEnabled()
     {
         return m_pMsRdpExtendedSettings && m_pMsRdpExtendedSettings->GetVideoRecordingCursor();
@@ -359,18 +369,19 @@ private:
 
     void EmitCursorFrame()
     {
-        if (!m_OutputMirror || !IsCursorOverlayEnabled())
+        MsRdpEx_OutputMirror* outputMirror = GetOutputMirror();
+        if (!outputMirror || !IsCursorOverlayEnabled())
             return;
 
         bool outputMirrorEnabled = false;
         if (FAILED(GetOutputMirrorEnabled(&outputMirrorEnabled)) || !outputMirrorEnabled)
             return;
 
-        MsRdpEx_OutputMirror_Lock(m_OutputMirror);
+        MsRdpEx_OutputMirror_Lock(outputMirror);
         MsRdpEx_CursorOverlay_DumpFrame(
-            m_CursorOverlay, m_OutputMirror,
+            m_CursorOverlay, outputMirror,
             m_hInputCaptureWnd, m_hOutputPresenterWnd);
-        MsRdpEx_OutputMirror_Unlock(m_OutputMirror);
+        MsRdpEx_OutputMirror_Unlock(outputMirror);
     }
 
 public:
@@ -406,6 +417,103 @@ CMsRdpExInstance* CMsRdpExInstance_New(CMsRdpClient* pMsRdpClient)
 {
     CMsRdpExInstance* instance = new CMsRdpExInstance(pMsRdpClient);
     return instance;
+}
+
+struct _MsRdpEx_OutputMirrorCapture
+{
+    IMsRdpExInstance* instance;
+    DWORD ownerThreadId;
+};
+
+HRESULT STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Create(
+    IUnknown* pInstance,
+    MsRdpEx_OutputMirrorCapture** ppCapture)
+{
+    if (!pInstance || !ppCapture)
+        return E_INVALIDARG;
+
+    *ppCapture = NULL;
+
+    IMsRdpExInstance* instance = NULL;
+    HRESULT hr = pInstance->QueryInterface(
+        IID_IMsRdpExInstance, (void**)&instance);
+    if (FAILED(hr))
+        return hr;
+
+    MsRdpEx_OutputMirrorCapture* capture =
+        new (std::nothrow) MsRdpEx_OutputMirrorCapture();
+    if (!capture)
+    {
+        instance->Release();
+        return E_OUTOFMEMORY;
+    }
+
+    capture->instance = instance;
+    capture->ownerThreadId = GetCurrentThreadId();
+    *ppCapture = capture;
+    return S_OK;
+}
+
+uint32_t STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_GetFrameVersion(
+    MsRdpEx_OutputMirrorCapture* pCapture)
+{
+    if (!pCapture || !pCapture->instance)
+        return 0;
+
+    MsRdpEx_OutputMirror* outputMirror = NULL;
+    if (FAILED(pCapture->instance->GetOutputMirrorObject(
+        (LPVOID*)&outputMirror)) || !outputMirror)
+    {
+        return 0;
+    }
+
+    return MsRdpEx_OutputMirror_GetFrameVersion(outputMirror);
+}
+
+bool STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_GetShadowBitmap(
+    MsRdpEx_OutputMirrorCapture* pCapture,
+    HDC* phDC,
+    HBITMAP* phBitmap,
+    uint8_t** pBitmapData,
+    uint32_t* pBitmapWidth,
+    uint32_t* pBitmapHeight,
+    uint32_t* pBitmapStep)
+{
+    return pCapture && pCapture->instance &&
+        pCapture->instance->GetShadowBitmap(
+            phDC, phBitmap, pBitmapData,
+            pBitmapWidth, pBitmapHeight, pBitmapStep);
+}
+
+void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Lock(
+    MsRdpEx_OutputMirrorCapture* pCapture)
+{
+    if (pCapture && pCapture->instance)
+        pCapture->instance->LockShadowBitmap();
+}
+
+void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Unlock(
+    MsRdpEx_OutputMirrorCapture* pCapture)
+{
+    if (pCapture && pCapture->instance)
+        pCapture->instance->UnlockShadowBitmap();
+}
+
+void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Release(
+    MsRdpEx_OutputMirrorCapture* pCapture)
+{
+    if (!pCapture)
+        return;
+
+    if (pCapture->ownerThreadId != GetCurrentThreadId())
+    {
+        MsRdpEx_LogPrint(ERROR,
+            "MsRdpEx_OutputMirrorCapture_Release must run on its creating thread");
+    }
+
+    if (pCapture->instance)
+        pCapture->instance->Release();
+    delete pCapture;
 }
 
 void MsRdpEx_RdpInstance_Free(CMsRdpExInstance* instance)

--- a/dotnet/CMakeLists.txt
+++ b/dotnet/CMakeLists.txt
@@ -8,11 +8,17 @@ include_external_msproject(AxInterop.MSTSCLib.Legacy
 include_external_msproject(Interop.MSTSCLib.Generated.WinForms
     "${CMAKE_CURRENT_SOURCE_DIR}/Interop.MSTSCLib.Generated.WinForms/Interop.MSTSCLib.Generated.WinForms.csproj")
 
+include_external_msproject(Devolutions.MsRdpEx.Avalonia
+    "${CMAKE_CURRENT_SOURCE_DIR}/Devolutions.MsRdpEx.Avalonia/Devolutions.MsRdpEx.Avalonia.csproj")
+
 include_external_msproject(Devolutions.MsRdpEx
     "${CMAKE_CURRENT_SOURCE_DIR}/Devolutions.MsRdpEx/Devolutions.MsRdpEx.csproj")
 
 include_external_msproject(MsRdpEx_App
     "${CMAKE_CURRENT_SOURCE_DIR}/MsRdpEx_App/MsRdpEx_App.csproj")
+
+include_external_msproject(MsRdpEx_AvaloniaApp
+    "${CMAKE_CURRENT_SOURCE_DIR}/MsRdpEx_AvaloniaApp/MsRdpEx_AvaloniaApp.csproj")
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Directory.Build.props.in"
     "${CMAKE_CURRENT_SOURCE_DIR}/Directory.Build.props" @ONLY)

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/Devolutions.MsRdpEx.Avalonia.csproj
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/Devolutions.MsRdpEx.Avalonia.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <AssemblyName>Devolutions.MsRdpEx.Avalonia</AssemblyName>
+    <RootNamespace>Devolutions.MsRdpEx.Avalonia</RootNamespace>
+    <Description>A pure Avalonia RDP client view backed by the MsRdpEx output mirror.</Description>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+    <OutputPath Condition="'$(CMakeOutputPath)' != ''">$(CMakeOutputPath)</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="12.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Interop.MSTSCLib.Generated\Interop.MSTSCLib.Generated.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/MsRdpExInstanceHandle.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/MsRdpExInstanceHandle.cs
@@ -10,18 +10,39 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
 {
     private static readonly Guid InterfaceId = new("94CDA65A-EFDF-4453-B8B2-2493A12D31C7");
     private readonly object syncRoot = new();
+    private readonly OutputMirrorCaptureApi? captureApi;
     private readonly OutputMirrorGetFrameVersion? getFrameVersion;
+    private nint capture;
     private nint instance;
 
     public MsRdpExInstanceHandle(
         nint rdpControl,
+        OutputMirrorCaptureApi? captureApi,
         OutputMirrorGetFrameVersion? getFrameVersion)
     {
+        this.captureApi = captureApi;
         this.getFrameVersion = getFrameVersion;
         Guid interfaceId = InterfaceId;
         int hr = Marshal.QueryInterface(rdpControl, ref interfaceId, out instance);
         Marshal.ThrowExceptionForHR(hr);
+
+        try
+        {
+            if (captureApi is not null)
+            {
+                hr = captureApi.Create(instance, out capture);
+                Marshal.ThrowExceptionForHR(hr);
+            }
+        }
+        catch
+        {
+            Marshal.Release(instance);
+            instance = 0;
+            throw;
+        }
     }
+
+    public bool CanCaptureOffThread => capture != 0;
 
     public void SetOutputMirrorEnabled(bool enabled)
     {
@@ -54,7 +75,16 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
         lock (syncRoot)
         {
             version = 0;
-            if (instance == 0 || getFrameVersion is null)
+            if (instance == 0)
+                return false;
+
+            if (capture != 0 && captureApi is not null)
+            {
+                version = captureApi.GetFrameVersion(capture);
+                return true;
+            }
+
+            if (getFrameVersion is null)
                 return false;
 
             nint* vtable = *(nint**)instance;
@@ -76,6 +106,10 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
         lock (syncRoot)
         {
             ObjectDisposedException.ThrowIf(instance == 0, this);
+
+            if (capture != 0 && captureApi is not null)
+                return WithNativeCapture(action, captureApi);
+
             nint* vtable = *(nint**)instance;
             var getShadowBitmap = (delegate* unmanaged[Stdcall]<nint, nint*, nint*, nint*, uint*, uint*, uint*, byte>)vtable[23];
             var lockShadowBitmap = (delegate* unmanaged[Stdcall]<nint, void>)vtable[24];
@@ -123,11 +157,93 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
             if (instance == 0)
                 return;
 
+            if (capture != 0)
+            {
+                captureApi!.Release(capture);
+                capture = 0;
+            }
+
             Marshal.Release(instance);
             instance = 0;
         }
     }
 
+    private bool WithNativeCapture(
+        Action<nint, int, int, int> action,
+        OutputMirrorCaptureApi api)
+    {
+        if (!api.GetShadowBitmap(
+            capture,
+            out _,
+            out _,
+            out nint data,
+            out uint width,
+            out uint height,
+            out uint stride) ||
+            data == 0 || width == 0 || height == 0 || stride == 0)
+        {
+            return false;
+        }
+
+        api.Lock(capture);
+        try
+        {
+            if (!api.GetShadowBitmap(
+                capture,
+                out _,
+                out _,
+                out data,
+                out width,
+                out height,
+                out stride) ||
+                data == 0 || width == 0 || height == 0 || stride == 0)
+            {
+                return false;
+            }
+
+            action(data, checked((int)width), checked((int)height), checked((int)stride));
+            return true;
+        }
+        finally
+        {
+            api.Unlock(capture);
+        }
+    }
+
+    internal sealed record OutputMirrorCaptureApi(
+        OutputMirrorCaptureCreate Create,
+        OutputMirrorCaptureGetFrameVersion GetFrameVersion,
+        OutputMirrorCaptureGetShadowBitmap GetShadowBitmap,
+        OutputMirrorCaptureLock Lock,
+        OutputMirrorCaptureUnlock Unlock,
+        OutputMirrorCaptureRelease Release);
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate uint OutputMirrorGetFrameVersion(nint outputMirror);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    internal delegate int OutputMirrorCaptureCreate(nint instance, out nint capture);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    internal delegate uint OutputMirrorCaptureGetFrameVersion(nint capture);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal delegate bool OutputMirrorCaptureGetShadowBitmap(
+        nint capture,
+        out nint dc,
+        out nint bitmap,
+        out nint data,
+        out uint width,
+        out uint height,
+        out uint stride);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    internal delegate void OutputMirrorCaptureLock(nint capture);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    internal delegate void OutputMirrorCaptureUnlock(nint capture);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    internal delegate void OutputMirrorCaptureRelease(nint capture);
 }

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/MsRdpExInstanceHandle.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/MsRdpExInstanceHandle.cs
@@ -1,0 +1,133 @@
+using System.Runtime.InteropServices;
+
+namespace Devolutions.MsRdpEx.Avalonia;
+
+/// <summary>
+/// A minimal, WinForms-free projection of the native IMsRdpExInstance methods
+/// required by the Avalonia sample.
+/// </summary>
+internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
+{
+    private static readonly Guid InterfaceId = new("94CDA65A-EFDF-4453-B8B2-2493A12D31C7");
+    private readonly object syncRoot = new();
+    private readonly OutputMirrorGetFrameVersion? getFrameVersion;
+    private nint instance;
+
+    public MsRdpExInstanceHandle(
+        nint rdpControl,
+        OutputMirrorGetFrameVersion? getFrameVersion)
+    {
+        this.getFrameVersion = getFrameVersion;
+        Guid interfaceId = InterfaceId;
+        int hr = Marshal.QueryInterface(rdpControl, ref interfaceId, out instance);
+        Marshal.ThrowExceptionForHR(hr);
+    }
+
+    public void SetOutputMirrorEnabled(bool enabled)
+    {
+        lock (syncRoot)
+        {
+            ObjectDisposedException.ThrowIf(instance == 0, this);
+            nint* vtable = *(nint**)instance;
+            var setEnabled = (delegate* unmanaged[Stdcall]<nint, byte, int>)vtable[8];
+            int hr = setEnabled(instance, enabled ? (byte)1 : (byte)0);
+            Marshal.ThrowExceptionForHR(hr);
+        }
+    }
+
+    public nint GetInputWindow()
+    {
+        lock (syncRoot)
+        {
+            ObjectDisposedException.ThrowIf(instance == 0, this);
+            nint* vtable = *(nint**)instance;
+            var getInputWindow = (delegate* unmanaged[Stdcall]<nint, nint*, int>)vtable[16];
+            nint window;
+            int hr = getInputWindow(instance, &window);
+            Marshal.ThrowExceptionForHR(hr);
+            return window;
+        }
+    }
+
+    public bool TryGetShadowBitmapFrameVersion(out uint version)
+    {
+        lock (syncRoot)
+        {
+            version = 0;
+            if (instance == 0 || getFrameVersion is null)
+                return false;
+
+            nint* vtable = *(nint**)instance;
+            var getOutputMirror = (delegate* unmanaged[Stdcall]<nint, nint*, int>)vtable[5];
+            nint outputMirror;
+            int hr = getOutputMirror(instance, &outputMirror);
+            if (hr < 0 || outputMirror == 0)
+                return false;
+
+            version = getFrameVersion(outputMirror);
+            return true;
+        }
+    }
+
+    public bool WithShadowBitmap(Action<nint, int, int, int> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        lock (syncRoot)
+        {
+            ObjectDisposedException.ThrowIf(instance == 0, this);
+            nint* vtable = *(nint**)instance;
+            var getShadowBitmap = (delegate* unmanaged[Stdcall]<nint, nint*, nint*, nint*, uint*, uint*, uint*, byte>)vtable[23];
+            var lockShadowBitmap = (delegate* unmanaged[Stdcall]<nint, void>)vtable[24];
+            var unlockShadowBitmap = (delegate* unmanaged[Stdcall]<nint, void>)vtable[25];
+
+            nint dc;
+            nint bitmap;
+            nint data;
+            uint width;
+            uint height;
+            uint stride;
+
+            if (getShadowBitmap(instance, &dc, &bitmap, &data, &width, &height, &stride) == 0 ||
+                data == 0 || width == 0 || height == 0 || stride == 0)
+            {
+                return false;
+            }
+
+            lockShadowBitmap(instance);
+
+            try
+            {
+                // The DIB can be replaced during a resize. Resolve it again while
+                // holding the native lock before copying any pixels.
+                if (getShadowBitmap(instance, &dc, &bitmap, &data, &width, &height, &stride) == 0 ||
+                    data == 0 || width == 0 || height == 0 || stride == 0)
+                {
+                    return false;
+                }
+
+                action(data, checked((int)width), checked((int)height), checked((int)stride));
+                return true;
+            }
+            finally
+            {
+                unlockShadowBitmap(instance);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (syncRoot)
+        {
+            if (instance == 0)
+                return;
+
+            Marshal.Release(instance);
+            instance = 0;
+        }
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate uint OutputMirrorGetFrameVersion(nint outputMirror);
+}

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
@@ -1,0 +1,42 @@
+# Devolutions.MsRdpEx.Avalonia
+
+`RdpClientView` is a reusable Windows-only Avalonia 12 `UserControl` that
+renders the MsRdpEx output-mirror bitmap without placing the RDP ActiveX HWND
+inside the Avalonia visual tree. It forwards pointer, wheel, keyboard, drag,
+cursor, and dynamic-resolution behavior to the off-screen RDP session.
+
+The hosting path does not use Windows Forms `AxHost`, Avalonia
+`NativeControlHost`, or ATL's ActiveX host. MsRdpEx directly implements the OLE
+client-site and in-place-site interfaces needed to activate the control in its
+off-screen HWND. Only the mirrored bitmap is presented in Avalonia.
+
+The view can connect with `RdpConnectionSettings`, or a host application can
+use `GetClient<T>()` after `ClientReady` to configure generated MSTSCLib
+interfaces directly before connecting.
+
+When consuming `Devolutions.MsRdpEx` from NuGet, enable the control and the
+required generated COM projection in the project file:
+
+```xml
+<PropertyGroup>
+  <MsRdpExAvalonia>true</MsRdpExAvalonia>
+</PropertyGroup>
+
+<ItemGroup>
+  <PackageReference Include="Avalonia" Version="12.1.1" />
+  <PackageReference Include="Devolutions.MsRdpEx" Version="..." />
+</ItemGroup>
+```
+
+Then place the view in Avalonia XAML:
+
+```xml
+<Window
+    xmlns="https://github.com/avaloniaui"
+    xmlns:rdp="using:Devolutions.MsRdpEx.Avalonia">
+  <rdp:RdpClientView x:Name="RdpView" />
+</Window>
+```
+
+Avalonia remains an application dependency so the base MsRdpEx package does
+not impose Avalonia on its WinForms and .NET Framework consumers.

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -64,6 +64,7 @@ internal sealed class RdpActiveXSession : IDisposable
     private static RdpOleHostSetBounds? rdpOleHostSetBounds;
     private static RdpOleHostTranslateAccelerator? rdpOleHostTranslateAccelerator;
     private static RdpOleHostRelease? rdpOleHostRelease;
+    private static MsRdpExInstanceHandle.OutputMirrorCaptureApi? outputMirrorCaptureApi;
     private static MsRdpExInstanceHandle.OutputMirrorGetFrameVersion? outputMirrorGetFrameVersion;
     private static readonly UIntPtr InputWindowSubclassId = new(1);
 
@@ -175,7 +176,10 @@ internal sealed class RdpActiveXSession : IDisposable
                     client = ProxyObject.Pack<IMsRdpClient10>(rawClient)
                         ?? throw new InvalidOperationException("The hosted control does not implement IMsRdpClient10.");
 
-                    instance = new MsRdpExInstanceHandle(control, outputMirrorGetFrameVersion);
+                    instance = new MsRdpExInstanceHandle(
+                        control,
+                        outputMirrorCaptureApi,
+                        outputMirrorGetFrameVersion);
                 }
                 finally
                 {
@@ -377,6 +381,8 @@ internal sealed class RdpActiveXSession : IDisposable
     {
         return instance?.WithShadowBitmap(action) == true;
     }
+
+    public bool CanCaptureOffThread => instance?.CanCaptureOffThread == true;
 
     public bool TryGetShadowBitmapFrameVersion(out uint version)
     {
@@ -580,6 +586,29 @@ internal sealed class RdpActiveXSession : IDisposable
             outputMirrorGetFrameVersion =
                 Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorGetFrameVersion>(export);
         }
+
+        outputMirrorCaptureApi ??= TryLoadOutputMirrorCaptureApi(library);
+    }
+
+    private static MsRdpExInstanceHandle.OutputMirrorCaptureApi? TryLoadOutputMirrorCaptureApi(nint library)
+    {
+        if (!NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirrorCapture_Create", out nint create) ||
+            !NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirrorCapture_GetFrameVersion", out nint getFrameVersion) ||
+            !NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirrorCapture_GetShadowBitmap", out nint getShadowBitmap) ||
+            !NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirrorCapture_Lock", out nint lockCapture) ||
+            !NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirrorCapture_Unlock", out nint unlockCapture) ||
+            !NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirrorCapture_Release", out nint release))
+        {
+            return null;
+        }
+
+        return new MsRdpExInstanceHandle.OutputMirrorCaptureApi(
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorCaptureCreate>(create),
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorCaptureGetFrameVersion>(getFrameVersion),
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorCaptureGetShadowBitmap>(getShadowBitmap),
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorCaptureLock>(lockCapture),
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorCaptureUnlock>(unlockCapture),
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorCaptureRelease>(release));
     }
 
     private static string ResolveLibraryPath(string? configuredPath)

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -1,0 +1,1008 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using MSTSCLib;
+using BinaryString = MsRdpEx.Interop.BinaryString;
+
+namespace Devolutions.MsRdpEx.Avalonia;
+
+/// <summary>
+/// Runs the Microsoft RDP ActiveX control in an off-screen HWND with a direct
+/// OLE client site and in-place site. The window is only the RDP session engine;
+/// presentation and input belong to the Avalonia control.
+/// </summary>
+internal sealed class RdpActiveXSession : IDisposable
+{
+    private const string StaticWindowClass = "STATIC";
+    private static readonly Guid IidIUnknown = new("00000000-0000-0000-C000-000000000046");
+    private static readonly Guid IidIClassFactory = new("00000001-0000-0000-C000-000000000046");
+
+    private const uint WsPopup = 0x80000000;
+    private const uint WsVisible = 0x10000000;
+    private const uint WsClipSiblings = 0x04000000;
+    private const uint WsClipChildren = 0x02000000;
+    private const uint WsTabStop = 0x00010000;
+    private const uint WsExToolWindow = 0x00000080;
+    private const uint WsExNoActivate = 0x08000000;
+
+    private const uint SwpNoActivate = 0x0010;
+    private const uint SwpShowWindow = 0x0040;
+
+    private const uint WmMouseMove = 0x0200;
+    private const uint WmLeftButtonDown = 0x0201;
+    private const uint WmLeftButtonUp = 0x0202;
+    private const uint WmRightButtonDown = 0x0204;
+    private const uint WmRightButtonUp = 0x0205;
+    private const uint WmMiddleButtonDown = 0x0207;
+    private const uint WmMiddleButtonUp = 0x0208;
+    private const uint WmMouseWheel = 0x020A;
+    private const uint WmXButtonDown = 0x020B;
+    private const uint WmXButtonUp = 0x020C;
+    private const uint WmMouseHorizontalWheel = 0x020E;
+    private const uint WmMouseLeave = 0x02A3;
+    private const uint WmSetCursor = 0x0020;
+    private const uint WmKeyDown = 0x0100;
+    private const uint WmKeyUp = 0x0101;
+    private const uint WmChar = 0x0102;
+    private const uint WmSystemKeyDown = 0x0104;
+    private const uint WmSystemKeyUp = 0x0105;
+    private const uint WmCaptureChanged = 0x0215;
+    private const uint WmNcDestroy = 0x0082;
+
+    private const uint MapvkVkToVsc = 0;
+    private const int HtClient = 1;
+    private const NativeMouseButtons MouseButtonMask = NativeMouseButtons.Left |
+                                                        NativeMouseButtons.Right |
+                                                        NativeMouseButtons.Middle |
+                                                        NativeMouseButtons.XButton1 |
+                                                        NativeMouseButtons.XButton2;
+
+    private static nint msRdpExModule;
+    private static string? loadedLibraryPath;
+    private static readonly object NativeActivationLock = new();
+    private static RdpOleHostAttach? rdpOleHostAttach;
+    private static RdpOleHostSetBounds? rdpOleHostSetBounds;
+    private static RdpOleHostTranslateAccelerator? rdpOleHostTranslateAccelerator;
+    private static RdpOleHostRelease? rdpOleHostRelease;
+    private static MsRdpExInstanceHandle.OutputMirrorGetFrameVersion? outputMirrorGetFrameVersion;
+    private static readonly UIntPtr InputWindowSubclassId = new(1);
+
+    private IMsRdpClient10? client;
+    private RdpClientEventSubscription? eventSubscription;
+    private readonly SubclassProc inputWindowSubclassProc;
+    private MsRdpExInstanceHandle? instance;
+    private nint hostWindow;
+    private nint oleHost;
+    private nint inputWindowSubclassHandle;
+    private bool oleInitialized;
+    private bool disposed;
+    private bool remoteMouseDragActive;
+    private int sessionDesktopWidth;
+    private int sessionDesktopHeight;
+
+    public bool IsReady => client is not null;
+    public bool IsConnectionActive { get; private set; }
+    public bool IsLoginCompleted { get; private set; }
+    public nint HostWindowHandle => hostWindow;
+    public nint InputWindowHandle => GetInputWindow();
+
+    public event EventHandler? Ready;
+    public event EventHandler? LoginCompleted;
+    public event EventHandler<RdpRemoteDesktopSizeChangedEventArgs>? RemoteDesktopSizeChanged;
+    public event EventHandler<RdpFocusReleasedEventArgs>? FocusReleased;
+    public event EventHandler<RdpStatusChangedEventArgs>? StatusChanged;
+
+    public RdpActiveXSession()
+    {
+        inputWindowSubclassProc = InputWindowSubclassProc;
+    }
+
+    public void Start(int width, int height, Guid classId, string axName, string? rdpExDll)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        if (client is not null)
+            return;
+
+        if (classId == Guid.Empty)
+            throw new ArgumentException("An RDP ActiveX class identifier is required.", nameof(classId));
+        if (string.IsNullOrWhiteSpace(axName))
+            throw new ArgumentException("An RDP ActiveX name is required.", nameof(axName));
+
+        string libraryPath = ResolveLibraryPath(rdpExDll);
+
+        try
+        {
+            int oleResult = OleInitialize(0);
+            Marshal.ThrowExceptionForHR(oleResult);
+            oleInitialized = true;
+
+            int surfaceWidth = ClampDesktopDimension(width);
+            int surfaceHeight = ClampDesktopDimension(height);
+            nint executable = GetModuleHandleW(null);
+
+            hostWindow = CreateWindowExW(
+                WsExToolWindow | WsExNoActivate,
+                StaticWindowClass,
+                null,
+                WsPopup | WsVisible | WsClipSiblings | WsClipChildren | WsTabStop,
+                -32000,
+                -32000,
+                surfaceWidth,
+                surfaceHeight,
+                0,
+                0,
+                executable,
+                0);
+
+            if (hostWindow == 0)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "The off-screen RDP host window could not be created.");
+
+            nint control;
+            lock (NativeActivationLock)
+            {
+                string normalizedPath = Path.GetFullPath(libraryPath);
+                if (loadedLibraryPath is not null &&
+                    !string.Equals(loadedLibraryPath, normalizedPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"RdpClientView already loaded MsRdpEx.dll from '{loadedLibraryPath}'. " +
+                        "All views in one process must use the same native library.");
+                }
+
+                Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", axName.Trim());
+                msRdpExModule = msRdpExModule == 0 ? NativeLibrary.Load(normalizedPath) : msRdpExModule;
+                loadedLibraryPath ??= normalizedPath;
+                EnsureOleHostExports(msRdpExModule);
+                control = CreateComInstance(msRdpExModule, classId);
+            }
+
+            unsafe
+            {
+                try
+                {
+                    NativeRect bounds = new()
+                    {
+                        Right = surfaceWidth,
+                        Bottom = surfaceHeight
+                    };
+                    int hr = rdpOleHostAttach!(control, hostWindow, ref bounds, out oleHost);
+                    Marshal.ThrowExceptionForHR(hr);
+
+                    object rawClient = ComInterfaceMarshaller<object>.ConvertToManaged((void*)control)
+                        ?? throw new InvalidOperationException("The ActiveX host returned an empty RDP control instance.");
+
+                    client = ProxyObject.Pack<IMsRdpClient10>(rawClient)
+                        ?? throw new InvalidOperationException("The hosted control does not implement IMsRdpClient10.");
+
+                    instance = new MsRdpExInstanceHandle(control, outputMirrorGetFrameVersion);
+                }
+                finally
+                {
+                    ComInterfaceMarshaller<object>.Free((void*)control);
+                }
+            }
+
+            SubscribeToClientEvents(client);
+            PublishStatus("RDP bitmap surface ready (MsRdpEx output mirror)." );
+            Ready?.Invoke(this, EventArgs.Empty);
+        }
+        catch
+        {
+            DisposeNativeResources();
+            throw;
+        }
+    }
+
+    public void Connect(RdpConnectionSettings settings, int width, int height)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        IMsRdpClient10 rdpClient = client
+            ?? throw new InvalidOperationException("The off-screen RDP session is not ready yet.");
+
+        if (string.IsNullOrWhiteSpace(settings.HostName))
+            throw new ArgumentException("A host name is required.", nameof(settings));
+
+        if (rdpClient.Connected != 0)
+            throw new InvalidOperationException("Disconnect the current session before connecting again.");
+
+        int desktopWidth = ClampDesktopDimension(width);
+        int desktopHeight = ClampDesktopDimension(height);
+        ResizeHost(desktopWidth, desktopHeight);
+        sessionDesktopWidth = desktopWidth;
+        sessionDesktopHeight = desktopHeight;
+
+        if (!string.IsNullOrWhiteSpace(settings.RdpFileContents))
+            rdpClient.MsRdpClientShell.RdpFileContents = new BinaryString(settings.RdpFileContents);
+
+        rdpClient.Server = new BinaryString(settings.HostName.Trim());
+        rdpClient.UserName = new BinaryString(settings.UserName.Trim());
+        rdpClient.Domain = new BinaryString(settings.Domain.Trim());
+        rdpClient.DesktopWidth = desktopWidth;
+        rdpClient.DesktopHeight = desktopHeight;
+        rdpClient.ColorDepth = 32;
+
+        IMsRdpClientAdvancedSettings8 advancedSettings = rdpClient.AdvancedSettings9;
+        advancedSettings.EnableCredSspSupport = true;
+        advancedSettings.SmartSizing = false;
+        advancedSettings.GrabFocusOnConnect = false;
+        advancedSettings.allowBackgroundInput = 1;
+        advancedSettings.RedirectClipboard = settings.RedirectClipboard;
+
+        object? rawClient = ProxyObject.Unpack(rdpClient);
+        IMsTscNonScriptable nonScriptable = ProxyObject.Pack<IMsTscNonScriptable>(rawClient)
+            ?? throw new InvalidOperationException("The RDP control does not expose its credential interface.");
+
+        EnableOutputMirror(rdpClient);
+
+        if (string.IsNullOrEmpty(settings.Password))
+            nonScriptable.ResetPassword();
+        else
+            nonScriptable.ClearTextPassword = new BinaryString(settings.Password);
+
+        ConnectClient(rdpClient, settings.HostName.Trim());
+    }
+
+    public void ConnectConfigured(int width, int height)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        IMsRdpClient10 rdpClient = client
+            ?? throw new InvalidOperationException("The off-screen RDP session is not ready yet.");
+        if (rdpClient.Connected != 0)
+            throw new InvalidOperationException("Disconnect the current session before connecting again.");
+
+        int desktopWidth = ClampDesktopDimension(width);
+        int desktopHeight = ClampDesktopDimension(height);
+        ResizeHost(desktopWidth, desktopHeight);
+        sessionDesktopWidth = desktopWidth;
+        sessionDesktopHeight = desktopHeight;
+        EnableOutputMirror(rdpClient);
+        ConnectClient(rdpClient, null);
+    }
+
+    public T GetClient<T>() where T : class
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        IMsRdpClient10 rdpClient = client
+            ?? throw new InvalidOperationException("The off-screen RDP session is not ready yet.");
+        object? rawClient = ProxyObject.Unpack(rdpClient);
+        return ProxyObject.Pack<T>(rawClient)
+            ?? throw new InvalidCastException($"The hosted RDP control does not implement {typeof(T).FullName}.");
+    }
+
+    public void Disconnect()
+    {
+        if (client is not null && client.Connected != 0)
+        {
+            PublishStatus("Disconnecting...");
+            client.Disconnect();
+        }
+    }
+
+    public bool ResizeDisplay(int width, int height, double renderScaling)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        IMsRdpClient10? rdpClient = client;
+        if (rdpClient is null)
+            return false;
+
+        int desktopWidth = MakeEven(ClampDesktopDimension(width));
+        int desktopHeight = MakeEven(ClampDesktopDimension(height));
+        ResizeHost(desktopWidth, desktopHeight);
+
+        if (!IsLoginCompleted || rdpClient.Connected == 0)
+            return false;
+
+        if (desktopWidth == sessionDesktopWidth && desktopHeight == sessionDesktopHeight)
+            return true;
+
+        uint desktopScaleFactor = GetDesktopScaleFactor(renderScaling);
+        uint deviceScaleFactor = desktopScaleFactor switch
+        {
+            < 125 => 100,
+            < 200 => 140,
+            _ => 180
+        };
+
+        try
+        {
+            rdpClient.UpdateSessionDisplaySettings(
+                (uint)desktopWidth,
+                (uint)desktopHeight,
+                (uint)desktopWidth,
+                (uint)desktopHeight,
+                0,
+                desktopScaleFactor,
+                deviceScaleFactor);
+            sessionDesktopWidth = desktopWidth;
+            sessionDesktopHeight = desktopHeight;
+            return true;
+        }
+        catch (COMException exception)
+        {
+            PublishStatus($"Dynamic resolution update failed: {exception.Message}");
+            return false;
+        }
+    }
+
+    public bool UpdateSessionDisplaySettings(
+        uint desktopWidth,
+        uint desktopHeight,
+        uint physicalWidth,
+        uint physicalHeight,
+        uint orientation,
+        uint desktopScaleFactor,
+        uint deviceScaleFactor)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        IMsRdpClient10? rdpClient = client;
+        if (rdpClient is null)
+            return false;
+
+        int hostWidth = MakeEven(ClampDesktopDimension(checked((int)desktopWidth)));
+        int hostHeight = MakeEven(ClampDesktopDimension(checked((int)desktopHeight)));
+        ResizeHost(hostWidth, hostHeight);
+
+        if (!IsLoginCompleted || rdpClient.Connected == 0)
+            return false;
+
+        try
+        {
+            rdpClient.UpdateSessionDisplaySettings(
+                (uint)hostWidth,
+                (uint)hostHeight,
+                physicalWidth,
+                physicalHeight,
+                orientation,
+                desktopScaleFactor,
+                deviceScaleFactor);
+            sessionDesktopWidth = hostWidth;
+            sessionDesktopHeight = hostHeight;
+            return true;
+        }
+        catch (COMException exception)
+        {
+            PublishStatus($"Dynamic resolution update failed: {exception.Message}");
+            return false;
+        }
+    }
+
+    public bool WithShadowBitmap(Action<nint, int, int, int> action)
+    {
+        return instance?.WithShadowBitmap(action) == true;
+    }
+
+    public bool TryGetShadowBitmapFrameVersion(out uint version)
+    {
+        if (instance is not null)
+            return instance.TryGetShadowBitmapFrameVersion(out version);
+
+        version = 0;
+        return false;
+    }
+
+    public void SendMouseMove(int x, int y, NativeMouseButtons buttons)
+    {
+        nint inputWindow = GetInputWindow();
+        if (inputWindow == 0)
+            return;
+
+        SendMessageW(inputWindow, WmMouseMove, (nuint)(uint)buttons, MakeLParam(x, y));
+        SynchronizeCursor(inputWindow);
+    }
+
+    public void SendMouseButton(
+        uint message, int x, int y, NativeMouseButtons buttons, ushort xButton = 0)
+    {
+        nint inputWindow = GetInputWindow();
+        if (inputWindow == 0)
+            return;
+
+        bool buttonDown = message is WmLeftButtonDown or WmRightButtonDown or WmMiddleButtonDown or WmXButtonDown;
+        bool finalButtonUp = message is WmLeftButtonUp or WmRightButtonUp or WmMiddleButtonUp or WmXButtonUp &&
+                             (buttons & MouseButtonMask) == NativeMouseButtons.None;
+
+        if (buttonDown)
+        {
+            EnsureInputWindowSubclass(inputWindow);
+            remoteMouseDragActive = true;
+        }
+        else if (finalButtonUp)
+        {
+            remoteMouseDragActive = false;
+        }
+
+        nuint wParam = (nuint)((uint)buttons | ((uint)xButton << 16));
+        SendMessageW(inputWindow, message, wParam, MakeLParam(x, y));
+        SynchronizeCursor(inputWindow);
+    }
+
+    public void SendMouseWheel(int x, int y, int delta, NativeMouseButtons buttons)
+    {
+        SendMouseWheelMessage(WmMouseWheel, x, y, delta, buttons);
+    }
+
+    public void SendMouseHorizontalWheel(int x, int y, int delta, NativeMouseButtons buttons)
+    {
+        SendMouseWheelMessage(WmMouseHorizontalWheel, x, y, delta, buttons);
+    }
+
+    public bool TryGetInputSize(out int width, out int height)
+    {
+        nint inputWindow = GetInputWindow();
+        if (inputWindow == 0 || !GetClientRect(inputWindow, out NativeRect bounds))
+        {
+            width = 0;
+            height = 0;
+            return false;
+        }
+
+        width = bounds.Right - bounds.Left;
+        height = bounds.Bottom - bounds.Top;
+        return width > 0 && height > 0;
+    }
+
+    public void SendMouseLeave()
+    {
+        nint inputWindow = GetInputWindow();
+        if (inputWindow != 0)
+            SendMessageW(inputWindow, WmMouseLeave, 0, 0);
+    }
+
+    public void SendKey(int virtualKey, bool keyUp, bool extended, bool systemKey)
+    {
+        uint scanCode = MapVirtualKeyW((uint)virtualKey, MapvkVkToVsc);
+        SendKey(virtualKey, scanCode, keyUp, extended, systemKey);
+    }
+
+    public void SendKey(int virtualKey, uint scanCode, bool keyUp, bool extended, bool systemKey)
+    {
+        nint inputWindow = GetInputWindow();
+        if (inputWindow == 0 || virtualKey == 0)
+            return;
+
+        nint lParam = 1 | ((nint)scanCode << 16);
+
+        if (extended)
+            lParam |= (nint)1 << 24;
+
+        if (systemKey)
+            lParam |= (nint)1 << 29;
+
+        if (keyUp)
+            lParam |= (nint)3 << 30;
+
+        uint message = systemKey
+            ? keyUp ? WmSystemKeyUp : WmSystemKeyDown
+            : keyUp ? WmKeyUp : WmKeyDown;
+
+        if (TryTranslateAccelerator(inputWindow, message, (nuint)virtualKey, lParam))
+            return;
+
+        SendMessageW(inputWindow, message, (nuint)virtualKey, lParam);
+    }
+
+    public void SendCharacter(char character)
+    {
+        nint inputWindow = GetInputWindow();
+        if (inputWindow != 0)
+            SendMessageW(inputWindow, WmChar, character, 0);
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+
+        disposed = true;
+
+        try
+        {
+            Disconnect();
+        }
+        catch (COMException)
+        {
+            // The ActiveX control may already be tearing down.
+        }
+
+        DisposeNativeResources();
+    }
+
+    private void ResizeHost(int width, int height)
+    {
+        if (hostWindow != 0)
+        {
+            SetWindowPos(hostWindow, 0, -32000, -32000, width, height, SwpNoActivate | SwpShowWindow);
+        }
+
+        if (oleHost != 0 && rdpOleHostSetBounds is not null)
+        {
+            NativeRect bounds = new()
+            {
+                Right = width,
+                Bottom = height
+            };
+            int hr = rdpOleHostSetBounds(oleHost, ref bounds);
+            if (hr < 0)
+                PublishStatus($"RDP OLE host resize failed: 0x{hr:X8}");
+        }
+    }
+
+    private void EnableOutputMirror(IMsRdpClient10 rdpClient)
+    {
+        object? rawClient = ProxyObject.Unpack(rdpClient);
+        IMsRdpExtendedSettings extendedSettings = ProxyObject.Pack<IMsRdpExtendedSettings>(rawClient)
+            ?? throw new InvalidOperationException("The RDP control does not expose MsRdpEx extended settings.");
+        extendedSettings.SetProperty(new BinaryString("OutputMirrorEnabled"), true);
+        extendedSettings.SetProperty(new BinaryString("EnableHardwareMode"), false);
+        instance?.SetOutputMirrorEnabled(true);
+    }
+
+    private void ConnectClient(IMsRdpClient10 rdpClient, string? hostName)
+    {
+        IsConnectionActive = true;
+        IsLoginCompleted = false;
+
+        try
+        {
+            PublishStatus(string.IsNullOrWhiteSpace(hostName)
+                ? "Connecting..."
+                : $"Connecting to {hostName}...");
+            rdpClient.Connect();
+        }
+        catch
+        {
+            IsConnectionActive = false;
+            throw;
+        }
+    }
+
+    private static void EnsureOleHostExports(nint library)
+    {
+        rdpOleHostAttach ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostAttach>(
+            NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_Attach"));
+        rdpOleHostSetBounds ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostSetBounds>(
+            NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_SetBounds"));
+        rdpOleHostTranslateAccelerator ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostTranslateAccelerator>(
+            NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_TranslateAccelerator"));
+        rdpOleHostRelease ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostRelease>(
+            NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_Release"));
+
+        if (outputMirrorGetFrameVersion is null &&
+            NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirror_GetFrameVersion", out nint export))
+        {
+            outputMirrorGetFrameVersion =
+                Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.OutputMirrorGetFrameVersion>(export);
+        }
+    }
+
+    private static string ResolveLibraryPath(string? configuredPath)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            string explicitPath = Path.IsPathFullyQualified(configuredPath)
+                ? configuredPath
+                : Path.GetFullPath(configuredPath, AppContext.BaseDirectory);
+            if (File.Exists(explicitPath))
+                return explicitPath;
+
+            throw new FileNotFoundException("The configured MsRdpEx.dll could not be found.", explicitPath);
+        }
+
+        string architecture = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X86 => "x86",
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            _ => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()
+        };
+        string[] candidates =
+        [
+            Path.Combine(AppContext.BaseDirectory, "MsRdpEx.dll"),
+            Path.Combine(AppContext.BaseDirectory, "runtimes", $"win-{architecture}", "native", "MsRdpEx.dll")
+        ];
+
+        foreach (string candidate in candidates)
+        {
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        throw new FileNotFoundException(
+            $"MsRdpEx.dll is required for Avalonia bitmap rendering. Expected a {architecture} native asset beside the application or under its runtimes folder.",
+            candidates[0]);
+    }
+
+    private static void SynchronizeCursor(nint inputWindow)
+    {
+        // The off-screen input HWND never receives the WM_SETCURSOR Windows would
+        // normally send before WM_MOUSEMOVE. Ask it to select its current remote
+        // cursor explicitly so the pointer over the Avalonia surface stays in sync.
+        SendMessageW(
+            inputWindow,
+            WmSetCursor,
+            unchecked((nuint)inputWindow),
+            MakeLParam(HtClient, (int)WmMouseMove));
+    }
+
+    private bool TryTranslateAccelerator(nint inputWindow, uint message, nuint wParam, nint lParam)
+    {
+        if (oleHost == 0 || rdpOleHostTranslateAccelerator is null)
+            return false;
+
+        NativePoint point = default;
+        GetCursorPos(out point);
+        NativeMessage nativeMessage = new()
+        {
+            Window = inputWindow,
+            Message = message,
+            WParam = wParam,
+            LParam = lParam,
+            Time = unchecked((uint)GetMessageTime()),
+            Point = point
+        };
+        return rdpOleHostTranslateAccelerator(oleHost, ref nativeMessage) == 0;
+    }
+
+    private void SendMouseWheelMessage(uint message, int x, int y, int delta, NativeMouseButtons buttons)
+    {
+        nint inputWindow = GetInputWindow();
+        if (inputWindow == 0)
+            return;
+
+        NativePoint point = new(x, y);
+        ClientToScreen(inputWindow, ref point);
+        nuint wParam = (nuint)((uint)(ushort)buttons | ((uint)(ushort)delta << 16));
+        SendMessageW(inputWindow, message, wParam, MakeLParam(point.X, point.Y));
+    }
+
+    private nint GetInputWindow()
+    {
+        try
+        {
+            return instance?.GetInputWindow() ?? 0;
+        }
+        catch (COMException)
+        {
+            return 0;
+        }
+    }
+
+    private void EnsureInputWindowSubclass(nint inputWindow)
+    {
+        if (inputWindow == 0 || inputWindowSubclassHandle == inputWindow)
+            return;
+
+        RemoveInputWindowSubclass();
+        if (SetWindowSubclass(inputWindow, inputWindowSubclassProc, InputWindowSubclassId, UIntPtr.Zero))
+            inputWindowSubclassHandle = inputWindow;
+    }
+
+    private nint InputWindowSubclassProc(
+        nint window,
+        uint message,
+        nint wParam,
+        nint lParam,
+        UIntPtr subclassId,
+        UIntPtr referenceData)
+    {
+        // The RDP input HWND captures on button-down. Avalonia then takes capture so
+        // its visible bitmap surface keeps receiving pointer moves. That handoff must
+        // not be interpreted by the hidden ActiveX control as a cancelled remote drag.
+        if (message == WmCaptureChanged && remoteMouseDragActive && !disposed)
+            return 0;
+
+        if (message == WmNcDestroy && inputWindowSubclassHandle == window)
+        {
+            RemoveWindowSubclass(window, inputWindowSubclassProc, subclassId);
+            inputWindowSubclassHandle = 0;
+        }
+
+        return DefSubclassProc(window, message, wParam, lParam);
+    }
+
+    private void RemoveInputWindowSubclass()
+    {
+        nint inputWindow = inputWindowSubclassHandle;
+        if (inputWindow == 0)
+            return;
+
+        inputWindowSubclassHandle = 0;
+        RemoveWindowSubclass(inputWindow, inputWindowSubclassProc, InputWindowSubclassId);
+    }
+
+    private void SubscribeToClientEvents(IMsRdpClient rdpClient)
+    {
+        eventSubscription = rdpClient.Subscribe();
+        eventSubscription.Connecting += () =>
+        {
+            IsConnectionActive = true;
+            PublishStatus("Connecting...");
+        };
+        eventSubscription.Connected += () => PublishStatus("Transport connected. Signing in...");
+        eventSubscription.LoginCompleted += () =>
+        {
+            IsLoginCompleted = true;
+            PublishStatus("Connected.");
+            LoginCompleted?.Invoke(this, EventArgs.Empty);
+        };
+        eventSubscription.RemoteDesktopSizeChanged += (width, height) =>
+            RemoteDesktopSizeChanged?.Invoke(this, new RdpRemoteDesktopSizeChangedEventArgs(width, height));
+        eventSubscription.FocusReleased += direction =>
+            FocusReleased?.Invoke(this, new RdpFocusReleasedEventArgs(direction));
+        eventSubscription.DisconnectedWithDetails += (_, args) =>
+        {
+            IsConnectionActive = false;
+            IsLoginCompleted = false;
+            string detail = string.IsNullOrWhiteSpace(args.DisconnectErrorMessage)
+                ? $"reason {args.DisconnectReason}"
+                : args.DisconnectErrorMessage;
+            PublishStatus($"Disconnected: {detail}");
+        };
+        eventSubscription.FatalError += errorCode => PublishStatus($"RDP fatal error: {errorCode}");
+        eventSubscription.LogonError += errorCode => PublishStatus($"RDP logon error: {errorCode}");
+        eventSubscription.AuthenticationWarningDisplayed += () => PublishStatus("Waiting for certificate confirmation...");
+    }
+
+    private void PublishStatus(string message)
+    {
+        StatusChanged?.Invoke(this, new RdpStatusChangedEventArgs(message));
+    }
+
+    private void DisposeNativeResources()
+    {
+        remoteMouseDragActive = false;
+        RemoveInputWindowSubclass();
+
+        try
+        {
+            eventSubscription?.Dispose();
+        }
+        catch (COMException)
+        {
+            // The connection point can already be gone during control teardown.
+        }
+        finally
+        {
+            eventSubscription = null;
+        }
+
+        instance?.Dispose();
+        instance = null;
+
+        if (oleHost != 0)
+        {
+            nint host = oleHost;
+            oleHost = 0;
+            rdpOleHostRelease?.Invoke(host);
+        }
+
+        client = null;
+        IsConnectionActive = false;
+        IsLoginCompleted = false;
+
+        if (hostWindow != 0)
+        {
+            DestroyWindow(hostWindow);
+            hostWindow = 0;
+        }
+
+        if (oleInitialized)
+        {
+            OleUninitialize();
+            oleInitialized = false;
+        }
+    }
+
+    private static unsafe nint CreateComInstance(nint library, Guid classId)
+    {
+        nint export = NativeLibrary.GetExport(library, "DllGetClassObject");
+        DllGetClassObject getClassObject = Marshal.GetDelegateForFunctionPointer<DllGetClassObject>(export);
+
+        Guid classFactoryId = IidIClassFactory;
+        int hr = getClassObject(ref classId, ref classFactoryId, out nint factory);
+        Marshal.ThrowExceptionForHR(hr);
+
+        try
+        {
+            Guid unknownId = IidIUnknown;
+            nint instance;
+            nint* vtable = *(nint**)factory;
+            var createInstance = (delegate* unmanaged[Stdcall]<nint, nint, Guid*, nint*, int>)vtable[3];
+            hr = createInstance(factory, 0, &unknownId, &instance);
+            Marshal.ThrowExceptionForHR(hr);
+            return instance;
+        }
+        finally
+        {
+            Marshal.Release(factory);
+        }
+    }
+
+    private static nint MakeLParam(int x, int y)
+    {
+        return (nint)((uint)(ushort)x | ((uint)(ushort)y << 16));
+    }
+
+    private static int MakeEven(int value)
+    {
+        return value - (value % 2);
+    }
+
+    private static int ClampDesktopDimension(int value)
+    {
+        // Modern Microsoft RDP controls accept desktop dimensions from 200 to
+        // 8192 pixels. Clamp explicitly so small panes and extreme HiDPI layouts
+        // have deterministic behavior instead of failing later with E_INVALIDARG.
+        return Math.Clamp(value, 200, 8192);
+    }
+
+    private static uint GetDesktopScaleFactor(double renderScaling)
+    {
+        int percentage = Math.Clamp((int)Math.Round(renderScaling * 100), 100, 500);
+        return percentage switch
+        {
+            < 113 => 100,
+            < 138 => 125,
+            < 163 => 150,
+            < 188 => 175,
+            < 213 => 200,
+            < 238 => 225,
+            < 275 => 250,
+            < 350 => 300,
+            < 450 => 400,
+            _ => 500
+        };
+    }
+
+    [Flags]
+    internal enum NativeMouseButtons : uint
+    {
+        None = 0,
+        Left = 0x0001,
+        Right = 0x0002,
+        Shift = 0x0004,
+        Control = 0x0008,
+        Middle = 0x0010,
+        XButton1 = 0x0020,
+        XButton2 = 0x0040
+    }
+
+    internal static class MouseMessages
+    {
+        public const uint LeftDown = WmLeftButtonDown;
+        public const uint LeftUp = WmLeftButtonUp;
+        public const uint RightDown = WmRightButtonDown;
+        public const uint RightUp = WmRightButtonUp;
+        public const uint MiddleDown = WmMiddleButtonDown;
+        public const uint MiddleUp = WmMiddleButtonUp;
+        public const uint XDown = WmXButtonDown;
+        public const uint XUp = WmXButtonUp;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativePoint(int x, int y)
+    {
+        public int X = x;
+        public int Y = y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeMessage
+    {
+        public nint Window;
+        public uint Message;
+        public nuint WParam;
+        public nint LParam;
+        public uint Time;
+        public NativePoint Point;
+        public uint Private;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int DllGetClassObject(ref Guid classId, ref Guid interfaceId, out nint classFactory);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int RdpOleHostAttach(nint control, nint window, ref NativeRect bounds, out nint host);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int RdpOleHostSetBounds(nint host, ref NativeRect bounds);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int RdpOleHostTranslateAccelerator(nint host, ref NativeMessage message);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate void RdpOleHostRelease(nint host);
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate nint SubclassProc(
+        nint window,
+        uint message,
+        nint wParam,
+        nint lParam,
+        UIntPtr subclassId,
+        UIntPtr referenceData);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern nint GetModuleHandleW(string? moduleName);
+
+    [DllImport("ole32.dll", ExactSpelling = true)]
+    private static extern int OleInitialize(nint reserved);
+
+    [DllImport("ole32.dll", ExactSpelling = true)]
+    private static extern void OleUninitialize();
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+    private static extern nint CreateWindowExW(
+        uint extendedStyle,
+        string className,
+        string? windowName,
+        uint style,
+        int x,
+        int y,
+        int width,
+        int height,
+        nint parent,
+        nint menu,
+        nint module,
+        nint parameter);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DestroyWindow(nint window);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowPos(nint window, nint insertAfter, int x, int y, int width, int height, uint flags);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    private static extern nint SendMessageW(nint window, uint message, nuint wParam, nint lParam);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ClientToScreen(nint window, ref NativePoint point);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetClientRect(nint window, out NativeRect bounds);
+
+    [DllImport("user32.dll", ExactSpelling = true)]
+    private static extern uint MapVirtualKeyW(uint code, uint mapType);
+
+    [DllImport("user32.dll", ExactSpelling = true)]
+    private static extern int GetMessageTime();
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetCursorPos(out NativePoint point);
+
+    [DllImport("comctl32.dll", SetLastError = true, ExactSpelling = true)]
+    private static extern nint DefSubclassProc(nint window, uint message, nint wParam, nint lParam);
+
+    [DllImport("comctl32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowSubclass(
+        nint window,
+        SubclassProc subclassProc,
+        UIntPtr subclassId,
+        UIntPtr referenceData);
+
+    [DllImport("comctl32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool RemoveWindowSubclass(nint window, SubclassProc subclassProc, UIntPtr subclassId);
+}

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientEventArgs.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientEventArgs.cs
@@ -1,0 +1,18 @@
+namespace Devolutions.MsRdpEx.Avalonia;
+
+/// <summary>
+/// Reports the remote desktop size acknowledged by the RDP ActiveX control.
+/// </summary>
+public sealed class RdpRemoteDesktopSizeChangedEventArgs(int width, int height) : EventArgs
+{
+    public int Width { get; } = width;
+    public int Height { get; } = height;
+}
+
+/// <summary>
+/// Reports that the RDP control released keyboard focus at an edge of its tab order.
+/// </summary>
+public sealed class RdpFocusReleasedEventArgs(int direction) : EventArgs
+{
+    public int Direction { get; } = direction;
+}

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -38,6 +38,7 @@ public class RdpClientView : UserControl, IDisposable
     private readonly object frameLock = new();
     private readonly DispatcherTimer mouseDragTimer;
     private readonly DispatcherTimer resizeTimer;
+    private readonly DispatcherTimer staCaptureTimer;
     private readonly LowLevelKeyboardProc keyboardHookProc;
     private RdpActiveXSession? session;
     private WriteableBitmap? frameBitmap;
@@ -54,6 +55,7 @@ public class RdpClientView : UserControl, IDisposable
     private TopLevel? topLevel;
     private nint keyboardHook;
     private CancellationTokenSource? captureCancellation;
+    private Task? captureTask;
     private int captureGeneration;
     private int invalidateQueued;
     private int captureFailureReported;
@@ -65,6 +67,8 @@ public class RdpClientView : UserControl, IDisposable
     private bool isViewOnly;
     private bool viewportChangedQueued;
     private PixelSize viewportPixelSize;
+    private uint staFrameVersion;
+    private bool staHasFrameVersion;
     private bool disposed;
 
     public RdpClientView()
@@ -84,6 +88,12 @@ public class RdpClientView : UserControl, IDisposable
             Interval = TimeSpan.FromMilliseconds(250)
         };
         resizeTimer.Tick += OnResizeTimerTick;
+
+        staCaptureTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(33)
+        };
+        staCaptureTimer.Tick += OnStaCaptureTimerTick;
         GotFocus += OnControlGotFocus;
         LostFocus += OnControlLostFocus;
         DragDrop.SetAllowDrop(this, true);
@@ -837,19 +847,44 @@ public class RdpClientView : UserControl, IDisposable
     private void StartCaptureWorker()
     {
         StopCaptureWorker();
+        staFrameVersion = 0;
+        staHasFrameVersion = false;
+        Interlocked.Exchange(ref captureFailureReported, 0);
+
+        // Older MsRdpEx builds do not expose the capture-only native handle.
+        // Keep their apartment-bound instance calls on the Avalonia STA.
+        if (session?.CanCaptureOffThread != true)
+        {
+            staCaptureTimer.Start();
+            return;
+        }
+
         int generation = Interlocked.Increment(ref captureGeneration);
         CancellationTokenSource cancellation = new();
         captureCancellation = cancellation;
-        Interlocked.Exchange(ref captureFailureReported, 0);
-        _ = Task.Run(() => RunCaptureWorkerAsync(generation, cancellation));
+        captureTask = Task.Run(() => RunCaptureWorkerAsync(generation, cancellation));
     }
 
     private void StopCaptureWorker()
     {
+        staCaptureTimer.Stop();
         CancellationTokenSource? cancellation = captureCancellation;
         captureCancellation = null;
         Interlocked.Increment(ref captureGeneration);
         cancellation?.Cancel();
+
+        Task? task = captureTask;
+        captureTask = null;
+        if (task is not null)
+        {
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException) when (cancellation?.IsCancellationRequested == true)
+            {
+            }
+        }
     }
 
     private async Task RunCaptureWorkerAsync(
@@ -865,23 +900,7 @@ public class RdpClientView : UserControl, IDisposable
             while (!cancellationToken.IsCancellationRequested &&
                    generation == Volatile.Read(ref captureGeneration) && !disposed)
             {
-                uint frameVersion = 0;
-                // The export is optional so applications can still load an older
-                // MsRdpEx.dll; those DLLs retain the historical 30 fps copy path.
-                bool versionAvailable = session?.TryGetShadowBitmapFrameVersion(out frameVersion) == true;
-                bool frameChanged = !versionAvailable || !hasFrameVersion || frameVersion != lastFrameVersion;
-
-                if (frameChanged && CaptureFrame())
-                {
-                    if (versionAvailable)
-                    {
-                        lastFrameVersion = frameVersion;
-                        hasFrameVersion = true;
-                    }
-
-                    Interlocked.Exchange(ref captureFailureReported, 0);
-                    QueueInvalidate();
-                }
+                TryCaptureChangedFrame(ref lastFrameVersion, ref hasFrameVersion);
 
                 await Task.Delay(33, cancellationToken).ConfigureAwait(false);
             }
@@ -894,6 +913,32 @@ public class RdpClientView : UserControl, IDisposable
             Interlocked.CompareExchange(ref captureCancellation, null, cancellation);
             cancellation.Dispose();
         }
+    }
+
+    private void OnStaCaptureTimerTick(object? sender, EventArgs e)
+    {
+        TryCaptureChangedFrame(ref staFrameVersion, ref staHasFrameVersion);
+    }
+
+    private void TryCaptureChangedFrame(ref uint lastFrameVersion, ref bool hasFrameVersion)
+    {
+        uint frameVersion = 0;
+        // The frame-version export is optional for the STA compatibility path;
+        // without it, retain the historical 30 fps copy behavior.
+        bool versionAvailable = session?.TryGetShadowBitmapFrameVersion(out frameVersion) == true;
+        bool frameChanged = !versionAvailable || !hasFrameVersion || frameVersion != lastFrameVersion;
+
+        if (!frameChanged || !CaptureFrame())
+            return;
+
+        if (versionAvailable)
+        {
+            lastFrameVersion = frameVersion;
+            hasFrameVersion = true;
+        }
+
+        Interlocked.Exchange(ref captureFailureReported, 0);
+        QueueInvalidate();
     }
 
     private unsafe bool CaptureFrame()

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -1,0 +1,1434 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using System.Runtime.InteropServices;
+using System.Text;
+using static Devolutions.MsRdpEx.Avalonia.RdpActiveXSession;
+
+namespace Devolutions.MsRdpEx.Avalonia;
+
+/// <summary>
+/// A pure Avalonia RDP surface. Pixels are copied from MsRdpEx's shadow DIB
+/// into a WriteableBitmap; no native HWND participates in the Avalonia visual
+/// tree.
+/// </summary>
+public class RdpClientView : UserControl, IDisposable
+{
+    /// <summary>
+    /// The Microsoft RDP Client Control version 11 class identifier.
+    /// </summary>
+    public static readonly Guid DefaultClassId = new("A0C63C30-F08D-4AB4-907C-34905D770C7D");
+
+    private const int WhKeyboardLl = 13;
+    private const uint WmKeyDown = 0x0100;
+    private const uint WmKeyUp = 0x0101;
+    private const uint WmSystemKeyDown = 0x0104;
+    private const uint WmSystemKeyUp = 0x0105;
+    private const uint LlkhfExtended = 0x01;
+    private const uint CfHDrop = 15;
+    private const uint GmemMoveable = 0x0002;
+    private const uint GmemZeroInit = 0x0040;
+
+    private readonly object frameLock = new();
+    private readonly DispatcherTimer mouseDragTimer;
+    private readonly DispatcherTimer resizeTimer;
+    private readonly LowLevelKeyboardProc keyboardHookProc;
+    private RdpActiveXSession? session;
+    private WriteableBitmap? frameBitmap;
+    private WriteableBitmap? backFrameBitmap;
+    private Rect frameDestination;
+    private NativeMouseButtons pressedButtons;
+    private readonly Dictionary<int, ForwardedKey> forwardedKeys = [];
+    private readonly HashSet<int> localShortcutKeys = [];
+    private int lastRemoteX;
+    private int lastRemoteY;
+    private bool dynamicResolutionEnabled;
+    private PixelSize pendingDesktopSize;
+    private double pendingRenderScaling = 1.0;
+    private TopLevel? topLevel;
+    private nint keyboardHook;
+    private CancellationTokenSource? captureCancellation;
+    private int captureGeneration;
+    private int invalidateQueued;
+    private int captureFailureReported;
+    private int resizeRetryCount;
+    private PixelSize initialFrameTarget;
+    private long initialFrameDeadline;
+    private bool initialLoginCompleted;
+    private bool waitingForInitialFrame;
+    private bool isViewOnly;
+    private bool viewportChangedQueued;
+    private PixelSize viewportPixelSize;
+    private bool disposed;
+
+    public RdpClientView()
+    {
+        Focusable = true;
+        ClipToBounds = true;
+        keyboardHookProc = KeyboardHookProc;
+
+        mouseDragTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(16)
+        };
+        mouseDragTimer.Tick += OnMouseDragTimerTick;
+
+        resizeTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(250)
+        };
+        resizeTimer.Tick += OnResizeTimerTick;
+        GotFocus += OnControlGotFocus;
+        LostFocus += OnControlLostFocus;
+        DragDrop.SetAllowDrop(this, true);
+        AddHandler(DragDrop.DragOverEvent, OnFileDragOver);
+        AddHandler(DragDrop.DropEvent, OnFileDrop);
+    }
+
+    public bool IsClientReady => session?.IsReady == true;
+    public bool IsConnectionActive => session?.IsConnectionActive == true;
+    public bool IsLoginCompleted => session?.IsLoginCompleted == true;
+    public nint HostWindowHandle => session?.HostWindowHandle ?? 0;
+    public nint InputWindowHandle => session?.InputWindowHandle ?? 0;
+    public PixelSize ViewportPixelSize => GetDesktopPixelSize();
+
+    /// <summary>
+    /// Gets or sets the RDP ActiveX class identifier. Set this before the view is attached.
+    /// </summary>
+    public Guid ClassId { get; set; } = DefaultClassId;
+
+    /// <summary>
+    /// Gets or sets the MsRdpEx ActiveX name. Set this before the view is attached.
+    /// </summary>
+    public string AxName { get; set; } = "mstsc";
+
+    /// <summary>
+    /// Gets or sets an optional path to MsRdpEx.dll. Relative paths are resolved from
+    /// the application base directory. Set this before the view is attached.
+    /// </summary>
+    public string? RdpExDll { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether Windows/system shortcuts are sent to the remote session.
+    /// Set to false to keep Alt+Tab, Alt+F4, Windows keys, and similar shortcuts local.
+    /// </summary>
+    public bool UseRemoteKeyboardShortcuts { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether local filesystem drops are offered to the remote session
+    /// through the Windows CF_HDROP clipboard format.
+    /// </summary>
+    public bool AllowFileDrop { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether pointer and keyboard input is suppressed while the
+    /// remote desktop remains visible.
+    /// </summary>
+    public bool IsViewOnly
+    {
+        get => isViewOnly;
+        set
+        {
+            if (isViewOnly == value)
+                return;
+
+            isViewOnly = value;
+            if (value)
+            {
+                ReleaseForwardedKeys();
+                ReleaseMouseButtons();
+            }
+        }
+    }
+
+    public event EventHandler? ClientReady;
+    public event EventHandler? LoginCompleted;
+    public event EventHandler<RdpRemoteDesktopSizeChangedEventArgs>? RemoteDesktopSizeChanged;
+    public event EventHandler<RdpFocusReleasedEventArgs>? FocusReleased;
+    public event EventHandler<RdpStatusChangedEventArgs>? StatusChanged;
+    public event EventHandler? ViewportPixelSizeChanged;
+
+    /// <summary>
+    /// Creates the off-screen ActiveX control immediately. Calling this method is
+    /// optional for normal visual-tree use, but lets an embedding application
+    /// configure the generated COM interfaces before the view is attached.
+    /// </summary>
+    public void Initialize()
+    {
+        VerifyAccess();
+        ObjectDisposedException.ThrowIf(disposed, this);
+        if (session is not null)
+            return;
+
+        RdpActiveXSession activeSession = new();
+        activeSession.Ready += OnSessionReady;
+        activeSession.LoginCompleted += OnSessionLoginCompleted;
+        activeSession.RemoteDesktopSizeChanged += OnSessionRemoteDesktopSizeChanged;
+        activeSession.FocusReleased += OnSessionFocusReleased;
+        activeSession.StatusChanged += OnSessionStatusChanged;
+        session = activeSession;
+
+        try
+        {
+            PixelSize desktopSize = GetDesktopPixelSize();
+            activeSession.Start(desktopSize.Width, desktopSize.Height, ClassId, AxName, RdpExDll);
+        }
+        catch
+        {
+            activeSession.Ready -= OnSessionReady;
+            activeSession.LoginCompleted -= OnSessionLoginCompleted;
+            activeSession.RemoteDesktopSizeChanged -= OnSessionRemoteDesktopSizeChanged;
+            activeSession.FocusReleased -= OnSessionFocusReleased;
+            activeSession.StatusChanged -= OnSessionStatusChanged;
+            activeSession.Dispose();
+            session = null;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gets a generated COM interface for advanced RDP client configuration.
+    /// This is available after <see cref="ClientReady"/> has fired.
+    /// </summary>
+    public T GetClient<T>() where T : class
+    {
+        VerifyAccess();
+        return (session ?? throw new InvalidOperationException("The RDP bitmap session is not ready yet."))
+            .GetClient<T>();
+    }
+
+    public void Connect(RdpConnectionSettings settings)
+    {
+        VerifyAccess();
+
+        RdpActiveXSession activeSession = session
+            ?? throw new InvalidOperationException("The RDP bitmap session is not ready yet.");
+        bool hasDesktopWidth = settings.DesktopWidth > 0;
+        bool hasDesktopHeight = settings.DesktopHeight > 0;
+        if (hasDesktopWidth != hasDesktopHeight)
+        {
+            throw new ArgumentException(
+                "DesktopWidth and DesktopHeight must either both be positive or both be zero for dynamic resolution.",
+                nameof(settings));
+        }
+
+        PixelSize viewportSize = GetDesktopPixelSize();
+        dynamicResolutionEnabled = !hasDesktopWidth;
+        int desktopWidth = settings.DesktopWidth > 0 ? settings.DesktopWidth : viewportSize.Width;
+        int desktopHeight = settings.DesktopHeight > 0 ? settings.DesktopHeight : viewportSize.Height;
+        PrepareInitialFrame(new PixelSize(
+            Math.Clamp(desktopWidth, 200, 8192),
+            Math.Clamp(desktopHeight, 200, 8192)));
+        activeSession.Connect(settings, desktopWidth, desktopHeight);
+    }
+
+    /// <summary>
+    /// Connects a client that the embedding application configured through
+    /// <see cref="GetClient{T}"/>. The configured server, credentials, gateway,
+    /// redirection, and security properties are left unchanged.
+    /// </summary>
+    public void ConnectConfigured(
+        bool manageDynamicResolution = false,
+        PixelSize? initialFrameSize = null)
+    {
+        VerifyAccess();
+
+        RdpActiveXSession activeSession = session
+            ?? throw new InvalidOperationException("The RDP bitmap session is not ready yet.");
+        MSTSCLib.IMsRdpClient client = activeSession.GetClient<MSTSCLib.IMsRdpClient>();
+        PixelSize viewportSize = GetDesktopPixelSize();
+        int desktopWidth = client.DesktopWidth > 0 ? client.DesktopWidth : viewportSize.Width;
+        int desktopHeight = client.DesktopHeight > 0 ? client.DesktopHeight : viewportSize.Height;
+        dynamicResolutionEnabled = manageDynamicResolution;
+        PixelSize targetSize = initialFrameSize ?? new PixelSize(desktopWidth, desktopHeight);
+        PrepareInitialFrame(new PixelSize(
+            Math.Clamp(targetSize.Width, 200, 8192),
+            Math.Clamp(targetSize.Height, 200, 8192)));
+        activeSession.ConnectConfigured(desktopWidth, desktopHeight);
+    }
+
+    public bool TryUpdateSessionDisplaySettings(
+        uint desktopWidth,
+        uint desktopHeight,
+        uint physicalWidth,
+        uint physicalHeight,
+        uint orientation,
+        uint desktopScaleFactor,
+        uint deviceScaleFactor)
+    {
+        VerifyAccess();
+        return session?.UpdateSessionDisplaySettings(
+            desktopWidth,
+            desktopHeight,
+            physicalWidth,
+            physicalHeight,
+            orientation,
+            desktopScaleFactor,
+            deviceScaleFactor) == true;
+    }
+
+    public void Disconnect()
+    {
+        VerifyAccess();
+        session?.Disconnect();
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        context.FillRectangle(Brushes.Black, Bounds);
+
+        lock (frameLock)
+        {
+            if (frameBitmap is null)
+            {
+                frameDestination = default;
+                return;
+            }
+
+            frameDestination = CalculateAspectFit(Bounds, frameBitmap.PixelSize);
+            context.DrawImage(
+                frameBitmap,
+                new Rect(0, 0, frameBitmap.PixelSize.Width, frameBitmap.PixelSize.Height),
+                frameDestination);
+        }
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        ObjectDisposedException.ThrowIf(disposed, this);
+        topLevel = TopLevel.GetTopLevel(this);
+
+        try
+        {
+            Initialize();
+            StartCaptureWorker();
+        }
+        catch (Exception exception)
+        {
+            PublishStatus($"RDP initialization failed: {exception.Message}");
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        StopCaptureWorker();
+        UninstallKeyboardHook();
+        mouseDragTimer.Stop();
+        resizeTimer.Stop();
+        ReleaseForwardedKeys();
+        ReleaseMouseButtons();
+        topLevel = null;
+
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    /// <summary>
+    /// Permanently closes the hosted session and releases its native OLE resources.
+    /// Visual-tree detaches alone intentionally preserve the session for docking and
+    /// tab reparenting; owners should call Dispose when the view is truly closed.
+    /// </summary>
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+
+        VerifyAccess();
+        disposed = true;
+        StopCaptureWorker();
+        UninstallKeyboardHook();
+        mouseDragTimer.Stop();
+        resizeTimer.Stop();
+        ReleaseForwardedKeys();
+        ReleaseMouseButtons();
+
+        if (session is not null)
+        {
+            session.Ready -= OnSessionReady;
+            session.LoginCompleted -= OnSessionLoginCompleted;
+            session.RemoteDesktopSizeChanged -= OnSessionRemoteDesktopSizeChanged;
+            session.FocusReleased -= OnSessionFocusReleased;
+            session.StatusChanged -= OnSessionStatusChanged;
+            session.Dispose();
+            session = null;
+        }
+
+        lock (frameLock)
+        {
+            frameBitmap?.Dispose();
+            frameBitmap = null;
+            backFrameBitmap?.Dispose();
+            backFrameBitmap = null;
+        }
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        Size arrangedSize = base.ArrangeOverride(finalSize);
+        QueueViewportPixelSizeChanged(arrangedSize);
+        QueueDynamicResize(arrangedSize);
+        return arrangedSize;
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+
+        if (IsViewOnly)
+            return;
+
+        if (TryMapToRemote(e.GetPosition(this), out int x, out int y))
+        {
+            pressedButtons |= GetMouseButtonState(e.GetCurrentPoint(this).Properties);
+            lastRemoteX = x;
+            lastRemoteY = y;
+            session?.SendMouseMove(x, y, pressedButtons | GetModifierButtons(e.KeyModifiers));
+            e.Handled = true;
+        }
+        else if (pressedButtons == NativeMouseButtons.None)
+        {
+            session?.SendMouseLeave();
+        }
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        Focus();
+
+        if (IsViewOnly)
+            return;
+
+        if (!TryMapToRemote(e.GetPosition(this), out int x, out int y))
+            return;
+
+        PointerUpdateKind kind = e.GetCurrentPoint(this).Properties.PointerUpdateKind;
+        uint message;
+
+        switch (kind)
+        {
+            case PointerUpdateKind.LeftButtonPressed:
+                pressedButtons |= NativeMouseButtons.Left;
+                message = MouseMessages.LeftDown;
+                break;
+            case PointerUpdateKind.RightButtonPressed:
+                pressedButtons |= NativeMouseButtons.Right;
+                message = MouseMessages.RightDown;
+                break;
+            case PointerUpdateKind.MiddleButtonPressed:
+                pressedButtons |= NativeMouseButtons.Middle;
+                message = MouseMessages.MiddleDown;
+                break;
+            case PointerUpdateKind.XButton1Pressed:
+                pressedButtons |= NativeMouseButtons.XButton1;
+                message = MouseMessages.XDown;
+                break;
+            case PointerUpdateKind.XButton2Pressed:
+                pressedButtons |= NativeMouseButtons.XButton2;
+                message = MouseMessages.XDown;
+                break;
+            default:
+                return;
+        }
+
+        lastRemoteX = x;
+        lastRemoteY = y;
+        ushort xButton = kind is PointerUpdateKind.XButton1Pressed ? (ushort)1
+            : kind is PointerUpdateKind.XButton2Pressed ? (ushort)2 : (ushort)0;
+        session?.SendMouseButton(
+            message, x, y, pressedButtons | GetModifierButtons(e.KeyModifiers), xButton);
+        e.Pointer.Capture(this);
+        mouseDragTimer.Start();
+        e.Handled = true;
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+
+        if (IsViewOnly)
+        {
+            ReleaseMouseButtons();
+            return;
+        }
+
+        if (!TryMapToRemote(e.GetPosition(this), out int x, out int y, true))
+            return;
+
+        PointerUpdateKind kind = e.GetCurrentPoint(this).Properties.PointerUpdateKind;
+        uint message;
+
+        switch (kind)
+        {
+            case PointerUpdateKind.LeftButtonReleased:
+                pressedButtons &= ~NativeMouseButtons.Left;
+                message = MouseMessages.LeftUp;
+                break;
+            case PointerUpdateKind.RightButtonReleased:
+                pressedButtons &= ~NativeMouseButtons.Right;
+                message = MouseMessages.RightUp;
+                break;
+            case PointerUpdateKind.MiddleButtonReleased:
+                pressedButtons &= ~NativeMouseButtons.Middle;
+                message = MouseMessages.MiddleUp;
+                break;
+            case PointerUpdateKind.XButton1Released:
+                pressedButtons &= ~NativeMouseButtons.XButton1;
+                message = MouseMessages.XUp;
+                break;
+            case PointerUpdateKind.XButton2Released:
+                pressedButtons &= ~NativeMouseButtons.XButton2;
+                message = MouseMessages.XUp;
+                break;
+            default:
+                return;
+        }
+
+        lastRemoteX = x;
+        lastRemoteY = y;
+        ushort xButton = kind is PointerUpdateKind.XButton1Released ? (ushort)1
+            : kind is PointerUpdateKind.XButton2Released ? (ushort)2 : (ushort)0;
+        session?.SendMouseButton(
+            message, x, y, pressedButtons | GetModifierButtons(e.KeyModifiers), xButton);
+
+        if (pressedButtons == NativeMouseButtons.None)
+        {
+            mouseDragTimer.Stop();
+            e.Pointer.Capture(null);
+
+            if (!frameDestination.Contains(e.GetPosition(this)))
+            {
+                session?.SendMouseLeave();
+            }
+        }
+
+        e.Handled = true;
+    }
+
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        base.OnPointerWheelChanged(e);
+
+        if (IsViewOnly)
+            return;
+
+        if (TryMapToRemote(e.GetPosition(this), out int x, out int y))
+        {
+            NativeMouseButtons buttons = pressedButtons | GetModifierButtons(e.KeyModifiers);
+            int verticalDelta = Math.Clamp((int)Math.Round(e.Delta.Y * 120), short.MinValue, short.MaxValue);
+            int horizontalDelta = Math.Clamp((int)Math.Round(e.Delta.X * 120), short.MinValue, short.MaxValue);
+
+            if (verticalDelta != 0)
+                session?.SendMouseWheel(x, y, verticalDelta, buttons);
+            if (horizontalDelta != 0)
+                session?.SendMouseHorizontalWheel(x, y, horizontalDelta, buttons);
+
+            e.Handled = verticalDelta != 0 || horizontalDelta != 0;
+        }
+    }
+
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        base.OnPointerExited(e);
+        if (pressedButtons == NativeMouseButtons.None)
+        {
+            session?.SendMouseLeave();
+        }
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+
+        if (IsViewOnly)
+            return;
+
+        if (TryGetVirtualKey(e.Key, out int virtualKey, out bool extended))
+        {
+            bool systemKey = IsSystemKey(e);
+            session?.SendKey(virtualKey, false, extended, systemKey);
+            forwardedKeys[virtualKey] = new ForwardedKey(0, extended, systemKey);
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnKeyUp(KeyEventArgs e)
+    {
+        base.OnKeyUp(e);
+
+        if (IsViewOnly)
+            return;
+
+        if (TryGetVirtualKey(e.Key, out int virtualKey, out bool extended))
+        {
+            bool systemKey = forwardedKeys.TryGetValue(virtualKey, out ForwardedKey forwarded)
+                ? forwarded.SystemKey
+                : IsSystemKey(e);
+            session?.SendKey(virtualKey, true, extended, systemKey);
+            forwardedKeys.Remove(virtualKey);
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        if (!ContinuePhysicalMouseDrag())
+            ReleaseMouseButtons();
+    }
+
+    private void OnControlLostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        UninstallKeyboardHook();
+        ReleaseForwardedKeys();
+        if (!ContinuePhysicalMouseDrag())
+            ReleaseMouseButtons();
+    }
+
+    private void OnControlGotFocus(object? sender, FocusChangedEventArgs e)
+    {
+        InstallKeyboardHook();
+    }
+
+    private void InstallKeyboardHook()
+    {
+        if (keyboardHook != 0 || disposed)
+            return;
+
+        keyboardHook = SetWindowsHookExW(WhKeyboardLl, keyboardHookProc, GetModuleHandleW(null), 0);
+        if (keyboardHook == 0)
+            PublishStatus($"RDP keyboard hook could not be installed (Win32 {Marshal.GetLastWin32Error()}).");
+    }
+
+    private void UninstallKeyboardHook()
+    {
+        nint hook = keyboardHook;
+        keyboardHook = 0;
+        if (hook != 0)
+            UnhookWindowsHookEx(hook);
+    }
+
+    private nint KeyboardHookProc(int code, nint wParam, nint lParam)
+    {
+        if (code < 0 || keyboardHook == 0 || IsViewOnly || !IsKeyboardFocusWithin ||
+            topLevel is Window { IsActive: false })
+        {
+            return CallNextHookEx(keyboardHook, code, wParam, lParam);
+        }
+
+        uint message = unchecked((uint)(nuint)wParam);
+        bool keyDown = message is WmKeyDown or WmSystemKeyDown;
+        bool keyUp = message is WmKeyUp or WmSystemKeyUp;
+        if (!keyDown && !keyUp)
+            return CallNextHookEx(keyboardHook, code, wParam, lParam);
+
+        KeyboardHookData keyData = Marshal.PtrToStructure<KeyboardHookData>(lParam);
+        int virtualKey = checked((int)keyData.VirtualKey);
+        if (ShouldHandleShortcutLocally(virtualKey, keyDown, keyUp))
+            return CallNextHookEx(keyboardHook, code, wParam, lParam);
+
+        // VK_PACKET carries the UTF-16 code unit in scanCode. This is the path
+        // used by Windows Unicode input injection and by RDM's IME bridge.
+        if (keyDown && virtualKey == 0xE7)
+        {
+            session?.SendCharacter((char)keyData.ScanCode);
+            return 1;
+        }
+
+        bool extended = (keyData.Flags & LlkhfExtended) != 0;
+        bool systemKey = message is WmSystemKeyDown or WmSystemKeyUp;
+        session?.SendKey(virtualKey, keyData.ScanCode, keyUp, extended, systemKey);
+
+        if (keyDown)
+            forwardedKeys[virtualKey] = new ForwardedKey(keyData.ScanCode, extended, systemKey);
+        else
+            forwardedKeys.Remove(virtualKey);
+
+        return 1;
+    }
+
+    private bool ShouldHandleShortcutLocally(int virtualKey, bool keyDown, bool keyUp)
+    {
+        if (UseRemoteKeyboardShortcuts)
+        {
+            localShortcutKeys.Clear();
+            return false;
+        }
+
+        if (keyUp && localShortcutKeys.Remove(virtualKey))
+            return true;
+
+        const int leftWindows = 0x5B;
+        const int rightWindows = 0x5C;
+        const int leftAlt = 0xA4;
+        const int rightAlt = 0xA5;
+        const int leftControl = 0xA2;
+        const int rightControl = 0xA3;
+
+        bool windowsKey = virtualKey is leftWindows or rightWindows;
+        int altKey = forwardedKeys.ContainsKey(leftAlt) ? leftAlt : rightAlt;
+        int controlKey = forwardedKeys.ContainsKey(leftControl) ? leftControl : rightControl;
+        bool altPressed = forwardedKeys.ContainsKey(altKey);
+        bool controlPressed = forwardedKeys.ContainsKey(controlKey);
+        bool localCombination = keyDown &&
+            ((altPressed && virtualKey is 0x09 or 0x1B or 0x73 or 0x20) ||
+             (controlPressed && virtualKey == 0x1B));
+        if (!windowsKey && !localCombination)
+            return false;
+
+        localShortcutKeys.Add(virtualKey);
+        if (altPressed)
+            localShortcutKeys.Add(altKey);
+        if (controlPressed)
+            localShortcutKeys.Add(controlKey);
+        ReleaseForwardedKeys();
+        return true;
+    }
+
+    private void OnFileDragOver(object? sender, DragEventArgs e)
+    {
+        e.DragEffects = !IsViewOnly && AllowFileDrop && IsConnectionActive &&
+            e.DataTransfer.Contains(DataFormat.File)
+                ? DragDropEffects.Copy
+                : DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private async void OnFileDrop(object? sender, DragEventArgs e)
+    {
+        if (IsViewOnly || !AllowFileDrop || !IsConnectionActive)
+        {
+            e.DragEffects = DragDropEffects.None;
+            e.Handled = true;
+            return;
+        }
+
+        IStorageItem[]? items = e.DataTransfer.TryGetFiles();
+        string[] paths = items?
+            .Select(item => item.Path.LocalPath)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .ToArray() ?? [];
+        if (paths.Length == 0 || !await TrySetFileDropClipboardAsync(paths))
+        {
+            e.DragEffects = DragDropEffects.None;
+            e.Handled = true;
+            return;
+        }
+
+        Focus();
+        await Task.Delay(200);
+        SendPasteShortcut();
+        e.DragEffects = DragDropEffects.Copy;
+        e.Handled = true;
+    }
+
+    private static async Task<bool> TrySetFileDropClipboardAsync(IReadOnlyList<string> paths)
+    {
+        string dropList = string.Join('\0', paths) + "\0\0";
+        byte[] encodedPaths = Encoding.Unicode.GetBytes(dropList);
+        int headerSize = Marshal.SizeOf<DropFiles>();
+        nint memory = GlobalAlloc(GmemMoveable | GmemZeroInit, (nuint)(headerSize + encodedPaths.Length));
+        if (memory == 0)
+            return false;
+
+        bool clipboardOwnsMemory = false;
+        try
+        {
+            nint data = GlobalLock(memory);
+            if (data == 0)
+                return false;
+
+            try
+            {
+                Marshal.StructureToPtr(new DropFiles
+                {
+                    Offset = (uint)headerSize,
+                    Wide = 1
+                }, data, false);
+                Marshal.Copy(encodedPaths, 0, data + headerSize, encodedPaths.Length);
+            }
+            finally
+            {
+                GlobalUnlock(memory);
+            }
+
+            bool clipboardOpened = false;
+            for (int attempt = 0; attempt < 8; attempt++)
+            {
+                if (OpenClipboard(0))
+                {
+                    clipboardOpened = true;
+                    break;
+                }
+                await Task.Delay(15);
+            }
+
+            if (!clipboardOpened)
+                return false;
+
+            try
+            {
+                if (!EmptyClipboard() || SetClipboardData(CfHDrop, memory) == 0)
+                    return false;
+                clipboardOwnsMemory = true;
+                return true;
+            }
+            finally
+            {
+                CloseClipboard();
+            }
+        }
+        finally
+        {
+            if (!clipboardOwnsMemory)
+                GlobalFree(memory);
+        }
+    }
+
+    private void SendPasteShortcut()
+    {
+        const int control = 0x11;
+        const int v = 0x56;
+        session?.SendKey(control, false, false, false);
+        session?.SendKey(v, false, false, false);
+        session?.SendKey(v, true, false, false);
+        session?.SendKey(control, true, false, false);
+    }
+
+    private void OnMouseDragTimerTick(object? sender, EventArgs e)
+    {
+        if (pressedButtons == NativeMouseButtons.None)
+        {
+            mouseDragTimer.Stop();
+            return;
+        }
+
+        NativeMouseButtons physicalButtons = GetPhysicalMouseButtonState();
+        if ((physicalButtons & pressedButtons) == NativeMouseButtons.None)
+        {
+            ReleaseMouseButtons();
+            return;
+        }
+
+        if (!GetCursorPos(out NativePoint screenPoint))
+            return;
+
+        PixelPoint canvasOrigin = this.PointToScreen(default);
+        double scaling = topLevel?.RenderScaling ?? 1.0;
+        Point localPoint = new(
+            (screenPoint.X - canvasOrigin.X) / scaling,
+            (screenPoint.Y - canvasOrigin.Y) / scaling);
+
+        if (!TryMapToRemote(localPoint, out int x, out int y, true))
+            return;
+
+        lastRemoteX = x;
+        lastRemoteY = y;
+        session?.SendMouseMove(x, y, pressedButtons);
+    }
+
+    private void StartCaptureWorker()
+    {
+        StopCaptureWorker();
+        int generation = Interlocked.Increment(ref captureGeneration);
+        CancellationTokenSource cancellation = new();
+        captureCancellation = cancellation;
+        Interlocked.Exchange(ref captureFailureReported, 0);
+        _ = Task.Run(() => RunCaptureWorkerAsync(generation, cancellation));
+    }
+
+    private void StopCaptureWorker()
+    {
+        CancellationTokenSource? cancellation = captureCancellation;
+        captureCancellation = null;
+        Interlocked.Increment(ref captureGeneration);
+        cancellation?.Cancel();
+    }
+
+    private async Task RunCaptureWorkerAsync(
+        int generation,
+        CancellationTokenSource cancellation)
+    {
+        uint lastFrameVersion = 0;
+        bool hasFrameVersion = false;
+
+        try
+        {
+            CancellationToken cancellationToken = cancellation.Token;
+            while (!cancellationToken.IsCancellationRequested &&
+                   generation == Volatile.Read(ref captureGeneration) && !disposed)
+            {
+                uint frameVersion = 0;
+                // The export is optional so applications can still load an older
+                // MsRdpEx.dll; those DLLs retain the historical 30 fps copy path.
+                bool versionAvailable = session?.TryGetShadowBitmapFrameVersion(out frameVersion) == true;
+                bool frameChanged = !versionAvailable || !hasFrameVersion || frameVersion != lastFrameVersion;
+
+                if (frameChanged && CaptureFrame())
+                {
+                    if (versionAvailable)
+                    {
+                        lastFrameVersion = frameVersion;
+                        hasFrameVersion = true;
+                    }
+
+                    Interlocked.Exchange(ref captureFailureReported, 0);
+                    QueueInvalidate();
+                }
+
+                await Task.Delay(33, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            Interlocked.CompareExchange(ref captureCancellation, null, cancellation);
+            cancellation.Dispose();
+        }
+    }
+
+    private unsafe bool CaptureFrame()
+    {
+        bool captured = false;
+        try
+        {
+            session?.WithShadowBitmap((source, width, height, sourceStride) =>
+            {
+                lock (frameLock)
+                {
+                    if (waitingForInitialFrame &&
+                        (!initialLoginCompleted ||
+                         (initialFrameTarget != new PixelSize(width, height) &&
+                          Environment.TickCount64 < initialFrameDeadline)))
+                    {
+                        return;
+                    }
+
+                    EnsureBackFrameBitmap(width, height);
+
+                    using ILockedFramebuffer destination = backFrameBitmap!.Lock();
+                    int bytesPerRow = checked(width * 4);
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        byte* sourceRow = (byte*)source + (y * sourceStride);
+                        byte* destinationRow = (byte*)destination.Address + (y * destination.RowBytes);
+                        Buffer.MemoryCopy(sourceRow, destinationRow, destination.RowBytes, bytesPerRow);
+                    }
+
+                    (frameBitmap, backFrameBitmap) = (backFrameBitmap, frameBitmap);
+                    waitingForInitialFrame = false;
+                    captured = true;
+                }
+            });
+        }
+        catch (ObjectDisposedException) when (disposed || captureCancellation is null)
+        {
+            return false;
+        }
+        catch (COMException exception)
+        {
+            if (Interlocked.Exchange(ref captureFailureReported, 1) == 0)
+            {
+                Dispatcher.UIThread.Post(
+                    () => PublishStatus($"RDP frame capture failed: {exception.Message}"),
+                    DispatcherPriority.Background);
+            }
+            return false;
+        }
+
+        return captured;
+    }
+
+    private void QueueInvalidate()
+    {
+        if (disposed || Interlocked.Exchange(ref invalidateQueued, 1) != 0)
+            return;
+
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                Interlocked.Exchange(ref invalidateQueued, 0);
+                if (!disposed)
+                    InvalidateVisual();
+            },
+            DispatcherPriority.Render);
+    }
+
+    private void OnResizeTimerTick(object? sender, EventArgs e)
+    {
+        resizeTimer.Stop();
+
+        if (!dynamicResolutionEnabled || pendingDesktopSize.Width <= 0 || pendingDesktopSize.Height <= 0)
+            return;
+
+        bool applied = session?.ResizeDisplay(
+            pendingDesktopSize.Width, pendingDesktopSize.Height, pendingRenderScaling) == true;
+        if (!applied && session?.IsLoginCompleted == true && resizeRetryCount < 4)
+        {
+            resizeRetryCount++;
+            resizeTimer.Interval = TimeSpan.FromMilliseconds(250 * (1 << resizeRetryCount));
+            resizeTimer.Start();
+        }
+    }
+
+    private void QueueDynamicResize(Size logicalSize)
+    {
+        if (!dynamicResolutionEnabled || session is null || logicalSize.Width <= 0 || logicalSize.Height <= 0)
+            return;
+
+        pendingRenderScaling = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
+        pendingDesktopSize = GetDesktopPixelSize(logicalSize, pendingRenderScaling);
+        lock (frameLock)
+        {
+            if (waitingForInitialFrame)
+                initialFrameTarget = pendingDesktopSize;
+        }
+        resizeRetryCount = 0;
+        resizeTimer.Interval = TimeSpan.FromMilliseconds(250);
+        resizeTimer.Stop();
+        resizeTimer.Start();
+    }
+
+    private void QueueViewportPixelSizeChanged(Size logicalSize)
+    {
+        if (logicalSize.Width <= 0 || logicalSize.Height <= 0)
+            return;
+
+        double scaling = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
+        PixelSize currentSize = GetDesktopPixelSize(logicalSize, scaling);
+        if (currentSize == viewportPixelSize)
+            return;
+
+        viewportPixelSize = currentSize;
+        if (viewportChangedQueued)
+            return;
+
+        viewportChangedQueued = true;
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                viewportChangedQueued = false;
+                if (!disposed)
+                    ViewportPixelSizeChanged?.Invoke(this, EventArgs.Empty);
+            },
+            DispatcherPriority.Background);
+    }
+
+    private void PrepareInitialFrame(PixelSize targetSize)
+    {
+        lock (frameLock)
+        {
+            initialFrameTarget = targetSize;
+            initialFrameDeadline = long.MaxValue;
+            initialLoginCompleted = false;
+            waitingForInitialFrame = true;
+            frameDestination = default;
+            frameBitmap?.Dispose();
+            frameBitmap = null;
+            backFrameBitmap?.Dispose();
+            backFrameBitmap = null;
+        }
+
+        InvalidateVisual();
+    }
+
+    private void EnsureBackFrameBitmap(int width, int height)
+    {
+        if (backFrameBitmap?.PixelSize == new PixelSize(width, height))
+            return;
+
+        backFrameBitmap?.Dispose();
+        backFrameBitmap = new WriteableBitmap(
+            new PixelSize(width, height),
+            new Vector(96, 96),
+            PixelFormat.Bgra8888,
+            AlphaFormat.Opaque);
+    }
+
+    private PixelSize GetDesktopPixelSize()
+    {
+        double scaling = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
+        return GetDesktopPixelSize(Bounds.Size, scaling);
+    }
+
+    private static PixelSize GetDesktopPixelSize(Size logicalSize, double scaling)
+    {
+        int width = Math.Clamp((int)Math.Round(logicalSize.Width * scaling), 200, 8192);
+        int height = Math.Clamp((int)Math.Round(logicalSize.Height * scaling), 200, 8192);
+        width -= width % 2;
+        height -= height % 2;
+        return new PixelSize(width, height);
+    }
+
+    private bool TryMapToRemote(Point point, out int x, out int y, bool clampOutside = false)
+    {
+        x = 0;
+        y = 0;
+
+        PixelSize frameSize;
+        lock (frameLock)
+            frameSize = frameBitmap?.PixelSize ?? default;
+
+        if (frameSize.Width <= 0 || frameSize.Height <= 0 ||
+            frameDestination.Width <= 0 || frameDestination.Height <= 0 ||
+            (!clampOutside && !frameDestination.Contains(point)))
+        {
+            return false;
+        }
+
+        int inputWidth = frameSize.Width;
+        int inputHeight = frameSize.Height;
+        session?.TryGetInputSize(out inputWidth, out inputHeight);
+
+        x = Math.Clamp(
+            (int)((point.X - frameDestination.X) * inputWidth / frameDestination.Width),
+            0,
+            inputWidth - 1);
+        y = Math.Clamp(
+            (int)((point.Y - frameDestination.Y) * inputHeight / frameDestination.Height),
+            0,
+            inputHeight - 1);
+        return true;
+    }
+
+    private void ReleaseForwardedKeys()
+    {
+        foreach ((int virtualKey, ForwardedKey key) in forwardedKeys)
+        {
+            if (key.ScanCode != 0)
+                session?.SendKey(virtualKey, key.ScanCode, true, key.Extended, key.SystemKey);
+            else
+                session?.SendKey(virtualKey, true, key.Extended, key.SystemKey);
+        }
+
+        forwardedKeys.Clear();
+    }
+
+    private void ReleaseMouseButtons()
+    {
+        NativeMouseButtons remaining = pressedButtons;
+        pressedButtons = NativeMouseButtons.None;
+        mouseDragTimer.Stop();
+
+        if (remaining.HasFlag(NativeMouseButtons.Left))
+        {
+            remaining &= ~NativeMouseButtons.Left;
+            session?.SendMouseButton(MouseMessages.LeftUp, lastRemoteX, lastRemoteY, remaining);
+        }
+
+        if (remaining.HasFlag(NativeMouseButtons.Right))
+        {
+            remaining &= ~NativeMouseButtons.Right;
+            session?.SendMouseButton(MouseMessages.RightUp, lastRemoteX, lastRemoteY, remaining);
+        }
+
+        if (remaining.HasFlag(NativeMouseButtons.Middle))
+        {
+            remaining &= ~NativeMouseButtons.Middle;
+            session?.SendMouseButton(MouseMessages.MiddleUp, lastRemoteX, lastRemoteY, remaining);
+        }
+
+
+        if (remaining.HasFlag(NativeMouseButtons.XButton1))
+        {
+            remaining &= ~NativeMouseButtons.XButton1;
+            session?.SendMouseButton(MouseMessages.XUp, lastRemoteX, lastRemoteY, remaining, 1);
+        }
+
+        if (remaining.HasFlag(NativeMouseButtons.XButton2))
+        {
+            remaining &= ~NativeMouseButtons.XButton2;
+            session?.SendMouseButton(MouseMessages.XUp, lastRemoteX, lastRemoteY, remaining, 2);
+        }
+    }
+
+    private bool ContinuePhysicalMouseDrag()
+    {
+        if (pressedButtons == NativeMouseButtons.None ||
+            (GetPhysicalMouseButtonState() & pressedButtons) == NativeMouseButtons.None)
+        {
+            return false;
+        }
+
+        mouseDragTimer.Start();
+        return true;
+    }
+
+    private static NativeMouseButtons GetMouseButtonState(PointerPointProperties properties)
+    {
+        NativeMouseButtons buttons = NativeMouseButtons.None;
+        if (properties.IsLeftButtonPressed)
+            buttons |= NativeMouseButtons.Left;
+        if (properties.IsRightButtonPressed)
+            buttons |= NativeMouseButtons.Right;
+        if (properties.IsMiddleButtonPressed)
+            buttons |= NativeMouseButtons.Middle;
+        if (properties.IsXButton1Pressed)
+            buttons |= NativeMouseButtons.XButton1;
+        if (properties.IsXButton2Pressed)
+            buttons |= NativeMouseButtons.XButton2;
+        return buttons;
+    }
+
+    private static NativeMouseButtons GetPhysicalMouseButtonState()
+    {
+        NativeMouseButtons buttons = NativeMouseButtons.None;
+        if (GetAsyncKeyState(0x01) < 0)
+            buttons |= NativeMouseButtons.Left;
+        if (GetAsyncKeyState(0x02) < 0)
+            buttons |= NativeMouseButtons.Right;
+        if (GetAsyncKeyState(0x04) < 0)
+            buttons |= NativeMouseButtons.Middle;
+        if (GetAsyncKeyState(0x05) < 0)
+            buttons |= NativeMouseButtons.XButton1;
+        if (GetAsyncKeyState(0x06) < 0)
+            buttons |= NativeMouseButtons.XButton2;
+        return buttons;
+    }
+
+    private static NativeMouseButtons GetModifierButtons(KeyModifiers modifiers)
+    {
+        NativeMouseButtons buttons = NativeMouseButtons.None;
+        if (modifiers.HasFlag(KeyModifiers.Shift))
+            buttons |= NativeMouseButtons.Shift;
+        if (modifiers.HasFlag(KeyModifiers.Control))
+            buttons |= NativeMouseButtons.Control;
+        return buttons;
+    }
+
+    private static bool IsSystemKey(KeyEventArgs e)
+    {
+        return e.KeyModifiers.HasFlag(KeyModifiers.Alt) || e.Key is Key.LeftAlt or Key.RightAlt;
+    }
+
+    private static Rect CalculateAspectFit(Rect bounds, PixelSize source)
+    {
+        if (bounds.Width <= 0 || bounds.Height <= 0 || source.Width <= 0 || source.Height <= 0)
+            return default;
+
+        double scale = Math.Min(bounds.Width / source.Width, bounds.Height / source.Height);
+        double width = source.Width * scale;
+        double height = source.Height * scale;
+        return new Rect(
+            bounds.X + ((bounds.Width - width) / 2),
+            bounds.Y + ((bounds.Height - height) / 2),
+            width,
+            height);
+    }
+
+    private void OnSessionReady(object? sender, EventArgs e)
+    {
+        ClientReady?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnSessionLoginCompleted(object? sender, EventArgs e)
+    {
+        QueueDynamicResize(Bounds.Size);
+        lock (frameLock)
+        {
+            // A non-conforming server should not leave the reusable control black
+            // forever, but normal connections only reveal a correctly sized frame.
+            initialFrameDeadline = Environment.TickCount64 + 5000;
+            initialLoginCompleted = true;
+        }
+        LoginCompleted?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnSessionRemoteDesktopSizeChanged(
+        object? sender, RdpRemoteDesktopSizeChangedEventArgs e)
+    {
+        RemoteDesktopSizeChanged?.Invoke(this, e);
+    }
+
+    private void OnSessionFocusReleased(object? sender, RdpFocusReleasedEventArgs e)
+    {
+        ReleaseForwardedKeys();
+        FocusReleased?.Invoke(this, e);
+    }
+
+    private void OnSessionStatusChanged(object? sender, RdpStatusChangedEventArgs e)
+    {
+        PublishStatus(e.Message);
+    }
+
+    private void PublishStatus(string message)
+    {
+        StatusChanged?.Invoke(this, new RdpStatusChangedEventArgs(message));
+    }
+
+    private static bool TryGetVirtualKey(Key key, out int virtualKey, out bool extended)
+    {
+        extended = false;
+
+        if (key is >= Key.D0 and <= Key.D9)
+        {
+            virtualKey = 0x30 + (key - Key.D0);
+            return true;
+        }
+
+        if (key is >= Key.A and <= Key.Z)
+        {
+            virtualKey = 0x41 + (key - Key.A);
+            return true;
+        }
+
+        if (key is >= Key.NumPad0 and <= Key.NumPad9)
+        {
+            virtualKey = 0x60 + (key - Key.NumPad0);
+            return true;
+        }
+
+        if (key is >= Key.F1 and <= Key.F24)
+        {
+            virtualKey = 0x70 + (key - Key.F1);
+            return true;
+        }
+
+        virtualKey = key switch
+        {
+            Key.Back => 0x08,
+            Key.Tab => 0x09,
+            Key.Clear => 0x0C,
+            Key.Return or Key.Enter => 0x0D,
+            Key.Pause => 0x13,
+            Key.CapsLock or Key.Capital => 0x14,
+            Key.Escape => 0x1B,
+            Key.Space => 0x20,
+            Key.PageUp or Key.Prior => 0x21,
+            Key.PageDown or Key.Next => 0x22,
+            Key.End => 0x23,
+            Key.Home => 0x24,
+            Key.Left => 0x25,
+            Key.Up => 0x26,
+            Key.Right => 0x27,
+            Key.Down => 0x28,
+            Key.Snapshot or Key.PrintScreen => 0x2C,
+            Key.Insert => 0x2D,
+            Key.Delete => 0x2E,
+            Key.LWin => 0x5B,
+            Key.RWin => 0x5C,
+            Key.Apps => 0x5D,
+            Key.Multiply => 0x6A,
+            Key.Add => 0x6B,
+            Key.Separator => 0x6C,
+            Key.Subtract => 0x6D,
+            Key.Decimal => 0x6E,
+            Key.Divide => 0x6F,
+            Key.NumLock => 0x90,
+            Key.Scroll => 0x91,
+            Key.LeftShift => 0xA0,
+            Key.RightShift => 0xA1,
+            Key.LeftCtrl => 0xA2,
+            Key.RightCtrl => 0xA3,
+            Key.LeftAlt => 0xA4,
+            Key.RightAlt => 0xA5,
+            Key.OemSemicolon or Key.Oem1 => 0xBA,
+            Key.OemPlus => 0xBB,
+            Key.OemComma => 0xBC,
+            Key.OemMinus => 0xBD,
+            Key.OemPeriod => 0xBE,
+            Key.OemQuestion or Key.Oem2 => 0xBF,
+            Key.OemTilde or Key.Oem3 => 0xC0,
+            Key.OemOpenBrackets or Key.Oem4 => 0xDB,
+            Key.OemPipe or Key.Oem5 => 0xDC,
+            Key.OemCloseBrackets or Key.Oem6 => 0xDD,
+            Key.OemQuotes or Key.Oem7 => 0xDE,
+            _ => 0
+        };
+
+        extended = key is Key.RightCtrl or Key.RightAlt or Key.Insert or Key.Delete or
+            Key.Home or Key.End or Key.PageUp or Key.PageDown or
+            Key.Left or Key.Up or Key.Right or Key.Down or Key.Divide or Key.NumLock;
+        return virtualKey != 0;
+    }
+
+    private readonly record struct ForwardedKey(uint ScanCode, bool Extended, bool SystemKey);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativePoint
+    {
+        public int X;
+        public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KeyboardHookData
+    {
+        public uint VirtualKey;
+        public uint ScanCode;
+        public uint Flags;
+        public uint Time;
+        public nuint ExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DropFiles
+    {
+        public uint Offset;
+        public NativePoint Point;
+        public int NonClient;
+        public int Wide;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate nint LowLevelKeyboardProc(int code, nint wParam, nint lParam);
+
+    [DllImport("user32.dll")]
+    private static extern short GetAsyncKeyState(int virtualKey);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetCursorPos(out NativePoint point);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern nint GetModuleHandleW(string? moduleName);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+    private static extern nint SetWindowsHookExW(
+        int hookType, LowLevelKeyboardProc callback, nint module, uint threadId);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UnhookWindowsHookEx(nint hook);
+
+    [DllImport("user32.dll", ExactSpelling = true)]
+    private static extern nint CallNextHookEx(nint hook, int code, nint wParam, nint lParam);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    private static extern nint GlobalAlloc(uint flags, nuint bytes);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    private static extern nint GlobalLock(nint memory);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GlobalUnlock(nint memory);
+
+    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+    private static extern nint GlobalFree(nint memory);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool OpenClipboard(nint owner);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseClipboard();
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EmptyClipboard();
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    private static extern nint SetClipboardData(uint format, nint memory);
+}

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpConnectionSettings.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpConnectionSettings.cs
@@ -1,0 +1,15 @@
+namespace Devolutions.MsRdpEx.Avalonia;
+
+/// <summary>
+/// Connection values used by <see cref="RdpClientView.Connect(RdpConnectionSettings)"/>.
+/// Passwords are passed directly to the RDP control and are not persisted by the view.
+/// </summary>
+public sealed record RdpConnectionSettings(
+    string HostName,
+    string UserName,
+    string Password,
+    string Domain,
+    int DesktopWidth = 0,
+    int DesktopHeight = 0,
+    string RdpFileContents = "",
+    bool RedirectClipboard = true);

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpStatusChangedEventArgs.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpStatusChangedEventArgs.cs
@@ -1,0 +1,9 @@
+namespace Devolutions.MsRdpEx.Avalonia;
+
+/// <summary>
+/// Describes a human-readable RDP session status update.
+/// </summary>
+public sealed class RdpStatusChangedEventArgs(string message) : EventArgs
+{
+    public string Message { get; } = message;
+}

--- a/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.csproj
+++ b/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="../AxInterop.MSTSCLib/AxInterop.MSTSCLib.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)' != 'net48'" />
     <ProjectReference Include="../Interop.MSTSCLib.Generated/Interop.MSTSCLib.Generated.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)' != 'net48'" />
     <ProjectReference Include="../Interop.MSTSCLib.Generated.WinForms/Interop.MSTSCLib.Generated.WinForms.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)' != 'net48'" />
+    <ProjectReference Include="../Devolutions.MsRdpEx.Avalonia/Devolutions.MsRdpEx.Avalonia.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)' != 'net48'" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
@@ -40,6 +41,7 @@
     <Content Include="$(CMakeOutputPath)\Interop.MSTSCLib.Generated.dll" PackagePath="interop/generated/Interop.MSTSCLib.Generated.dll" Pack="true" Visible="false" />
     <Content Include="$(CMakeOutputPath)\AxInterop.MSTSCLib.dll" PackagePath="interop/generated-winforms/AxInterop.MSTSCLib.dll" Pack="true" Visible="false" />
     <Content Include="$(CMakeOutputPath)\Interop.MSTSCLib.Generated.WinForms.dll" PackagePath="interop/generated-winforms/Interop.MSTSCLib.Generated.WinForms.dll" Pack="true" Visible="false" />
+    <Content Include="$(CMakeOutputPath)\Devolutions.MsRdpEx.Avalonia.dll" PackagePath="avalonia/net8.0-windows/Devolutions.MsRdpEx.Avalonia.dll" Pack="true" Visible="false" />
     <Content Include="../../dependencies/MsRdpEx/x86/MsRdpEx.dll" PackagePath="runtimes/win-x86/native/MsRdpEx.dll" Pack="true" Visible="false" Condition="Exists('../../dependencies/MsRdpEx/x86/MsRdpEx.dll')" />
     <Content Include="../../dependencies/MsRdpEx/x64/MsRdpEx.dll" PackagePath="runtimes/win-x64/native/MsRdpEx.dll" Pack="true" Visible="false" Condition="Exists('../../dependencies/MsRdpEx/x64/MsRdpEx.dll')" />
     <Content Include="../../dependencies/MsRdpEx/arm64/MsRdpEx.dll" PackagePath="runtimes/win-arm64/native/MsRdpEx.dll" Pack="true" Visible="false" Condition="Exists('../../dependencies/MsRdpEx/arm64/MsRdpEx.dll')" />

--- a/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.targets
+++ b/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.targets
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <MsRdpExAvalonia Condition="'$(MsRdpExAvalonia)' == ''">false</MsRdpExAvalonia>
+    <MsRdpExComInterop Condition="'$(MsRdpExComInterop)' == '' And '$(MsRdpExAvalonia)' == 'true'">Generated</MsRdpExComInterop>
     <MsRdpExComInterop Condition="'$(MsRdpExComInterop)' == ''">Legacy</MsRdpExComInterop>
     <MsRdpExGeneratedInteropSupported>true</MsRdpExGeneratedInteropSupported>
     <MsRdpExGeneratedWinFormsInteropSupported>true</MsRdpExGeneratedWinFormsInteropSupported>
     <MsRdpExGeneratedWinFormsHostSupported>true</MsRdpExGeneratedWinFormsHostSupported>
+    <MsRdpExAvaloniaSupported>true</MsRdpExAvaloniaSupported>
     <MsRdpExGeneratedWinForms Condition="'$(MsRdpExGeneratedWinForms)' == ''">false</MsRdpExGeneratedWinForms>
     <_MsRdpExPackageRoot>$(MSBuildThisFileDirectory)..\</_MsRdpExPackageRoot>
     <_MsRdpExLegacyInteropPath>$(_MsRdpExPackageRoot)interop\legacy\Interop.MSTSCLib.dll</_MsRdpExLegacyInteropPath>
@@ -13,6 +16,7 @@
     <_MsRdpExGeneratedInteropPath>$(_MsRdpExPackageRoot)interop\generated\Interop.MSTSCLib.Generated.dll</_MsRdpExGeneratedInteropPath>
     <_MsRdpExGeneratedWinFormsInteropPath>$(_MsRdpExPackageRoot)interop\generated-winforms\AxInterop.MSTSCLib.dll</_MsRdpExGeneratedWinFormsInteropPath>
     <_MsRdpExGeneratedWinFormsHostPath>$(_MsRdpExPackageRoot)interop\generated-winforms\Interop.MSTSCLib.Generated.WinForms.dll</_MsRdpExGeneratedWinFormsHostPath>
+    <_MsRdpExAvaloniaPath>$(_MsRdpExPackageRoot)avalonia\net8.0-windows\Devolutions.MsRdpEx.Avalonia.dll</_MsRdpExAvaloniaPath>
     <_MsRdpExNativeArchitecture Condition="'$(RuntimeIdentifier)' == '' And ('$(PlatformTarget)' == 'x86' Or '$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">x86</_MsRdpExNativeArchitecture>
     <_MsRdpExNativeArchitecture Condition="'$(RuntimeIdentifier)' == '' And ('$(PlatformTarget)' == 'x64' Or '$(Platform)' == 'x64')">x64</_MsRdpExNativeArchitecture>
     <_MsRdpExNativeArchitecture Condition="'$(RuntimeIdentifier)' == '' And ('$(PlatformTarget)' == 'arm64' Or '$(Platform)' == 'ARM64' Or '$(Platform)' == 'arm64')">arm64</_MsRdpExNativeArchitecture>
@@ -24,6 +28,8 @@
            Text="Unsupported MsRdpExComInterop value '$(MsRdpExComInterop)'. Use 'Legacy', 'Generated', 'GeneratedWinForms', or 'None'." />
     <Error Condition="'$(MsRdpExGeneratedWinForms)' != 'true' And '$(MsRdpExGeneratedWinForms)' != 'false'"
            Text="MsRdpExGeneratedWinForms must be 'true' or 'false'." />
+    <Error Condition="'$(MsRdpExAvalonia)' != 'true' And '$(MsRdpExAvalonia)' != 'false'"
+           Text="MsRdpExAvalonia must be 'true' or 'false'." />
     <Error Condition="'$(MsRdpExGeneratedWinForms)' == 'true' And '$(MsRdpExComInterop)' != 'Generated'"
            Text="MsRdpExGeneratedWinForms=true requires MsRdpExComInterop=Generated." />
     <Error Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And ('$(MsRdpExComInterop)' == 'Generated' Or '$(MsRdpExComInterop)' == 'GeneratedWinForms')"
@@ -34,6 +40,12 @@
            Text="MsRdpExGeneratedWinForms=true requires '$(_MsRdpExGeneratedWinFormsHostPath)', but the selected Devolutions.MsRdpEx package does not contain it. Select a package with MsRdpExGeneratedWinFormsHostSupported=true or disable WinForms hosting." />
     <Error Condition="'$(MsRdpExGeneratedWinForms)' == 'true' And '$(UseWindowsForms)' != 'true'"
            Text="MsRdpExGeneratedWinForms=true requires UseWindowsForms=true." />
+    <Error Condition="'$(MsRdpExAvalonia)' == 'true' And '$(MsRdpExComInterop)' != 'Generated'"
+           Text="MsRdpExAvalonia=true requires MsRdpExComInterop=Generated." />
+    <Error Condition="'$(MsRdpExAvalonia)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETCoreApp'"
+           Text="MsRdpExAvalonia=true requires a modern Windows .NET target such as net8.0-windows." />
+    <Error Condition="'$(MsRdpExAvalonia)' == 'true' And !Exists('$(_MsRdpExAvaloniaPath)')"
+           Text="MsRdpExAvalonia=true requires '$(_MsRdpExAvaloniaPath)', but the selected Devolutions.MsRdpEx package does not contain it. Select a package with MsRdpExAvaloniaSupported=true or disable the Avalonia view." />
     <Error Condition="'$(MsRdpExComInterop)' == 'Legacy' And (!Exists('$(_MsRdpExLegacyInteropPath)') Or !Exists('$(_MsRdpExLegacyAxInteropPath)'))"
            Text="MsRdpExComInterop=Legacy requires '$(_MsRdpExLegacyInteropPath)' and '$(_MsRdpExLegacyAxInteropPath)', but the selected Devolutions.MsRdpEx package does not contain its legacy interop assets." />
     <Error Condition="'$(MsRdpExComInterop)' == 'GeneratedWinForms' And (!Exists('$(_MsRdpExGeneratedInteropPath)') Or !Exists('$(_MsRdpExGeneratedWinFormsInteropPath)'))"
@@ -64,6 +76,14 @@
   <ItemGroup Condition="'$(MsRdpExComInterop)' == 'Generated' And '$(MsRdpExGeneratedWinForms)' == 'true'">
     <Reference Include="Interop.MSTSCLib.Generated.WinForms">
       <HintPath>$(_MsRdpExGeneratedWinFormsHostPath)</HintPath>
+      <Private>true</Private>
+      <SpecificVersion>false</SpecificVersion>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(MsRdpExAvalonia)' == 'true'">
+    <Reference Include="Devolutions.MsRdpEx.Avalonia">
+      <HintPath>$(_MsRdpExAvaloniaPath)</HintPath>
       <Private>true</Private>
       <SpecificVersion>false</SpecificVersion>
     </Reference>

--- a/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.targets
+++ b/dotnet/Devolutions.MsRdpEx/Devolutions.MsRdpEx.targets
@@ -42,8 +42,8 @@
            Text="MsRdpExGeneratedWinForms=true requires UseWindowsForms=true." />
     <Error Condition="'$(MsRdpExAvalonia)' == 'true' And '$(MsRdpExComInterop)' != 'Generated'"
            Text="MsRdpExAvalonia=true requires MsRdpExComInterop=Generated." />
-    <Error Condition="'$(MsRdpExAvalonia)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETCoreApp'"
-           Text="MsRdpExAvalonia=true requires a modern Windows .NET target such as net8.0-windows." />
+    <Error Condition="'$(MsRdpExAvalonia)' == 'true' And ('$(TargetFrameworkIdentifier)' != '.NETCoreApp' Or '$(TargetPlatformIdentifier)' != 'Windows' Or $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '8.0')))"
+           Text="MsRdpExAvalonia=true requires net8.0-windows or a later Windows target framework." />
     <Error Condition="'$(MsRdpExAvalonia)' == 'true' And !Exists('$(_MsRdpExAvaloniaPath)')"
            Text="MsRdpExAvalonia=true requires '$(_MsRdpExAvaloniaPath)', but the selected Devolutions.MsRdpEx package does not contain it. Select a package with MsRdpExAvaloniaSupported=true or disable the Avalonia view." />
     <Error Condition="'$(MsRdpExComInterop)' == 'Legacy' And (!Exists('$(_MsRdpExLegacyInteropPath)') Or !Exists('$(_MsRdpExLegacyAxInteropPath)'))"

--- a/dotnet/MsRdpEx_AvaloniaApp/App.axaml
+++ b/dotnet/MsRdpEx_AvaloniaApp/App.axaml
@@ -1,0 +1,9 @@
+<Application
+    x:Class="MsRdpEx_AvaloniaApp.App"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    RequestedThemeVariant="Default">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/dotnet/MsRdpEx_AvaloniaApp/App.axaml.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/App.axaml.cs
@@ -1,0 +1,32 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace MsRdpEx_AvaloniaApp;
+
+public sealed class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            RdpLaunchOptions launchOptions = RdpLaunchOptions.Parse(desktop.Args ?? []);
+            ConnectionDialog connectionDialog = new(launchOptions);
+            connectionDialog.ConnectionRequested += settings =>
+            {
+                MainWindow sessionWindow = new(settings, launchOptions);
+                desktop.MainWindow = sessionWindow;
+                sessionWindow.Show();
+                connectionDialog.Close();
+            };
+            desktop.MainWindow = connectionDialog;
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml
+++ b/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml
@@ -82,7 +82,6 @@
                     Grid.Row="2"
                     Grid.Column="1"
                     AutomationProperties.AutomationId="HostNameTextBox"
-                    Text="it-help-dc"
                     PlaceholderText="server.example.com" />
 
                 <TextBlock Grid.Row="3" VerticalAlignment="Center" Text="User name:" />
@@ -98,6 +97,8 @@
                     x:Name="PasswordTextBox"
                     Grid.Row="4"
                     Grid.Column="1"
+                    AutomationProperties.AutomationId="PasswordTextBox"
+                    AutomationProperties.Name="Password"
                     PasswordChar="●"
                     PlaceholderText="password" />
 

--- a/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml
+++ b/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml
@@ -1,0 +1,181 @@
+<Window
+    x:Class="MsRdpEx_AvaloniaApp.ConnectionDialog"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MsRdpEx_AvaloniaApp"
+    Title="Remote Desktop Connection"
+    Width="630"
+    Height="650"
+    CanResize="False"
+    WindowStartupLocation="CenterScreen">
+  <Grid RowDefinitions="112,*,Auto" Background="#F5F5F5">
+    <Border
+        BorderBrush="#B8C7D9"
+        BorderThickness="0,0,0,1"
+        Background="#EEF5FD">
+      <Grid Margin="28,12,24,12" ColumnDefinitions="76,*">
+        <Grid Width="62" Height="66" VerticalAlignment="Center">
+          <Border
+              Width="52"
+              Height="38"
+              HorizontalAlignment="Left"
+              VerticalAlignment="Top"
+              BorderBrush="#4F6380"
+              BorderThickness="2"
+              CornerRadius="2"
+              Background="#BFD8F4">
+            <Border Margin="4" Background="#EAF4FF" />
+          </Border>
+          <Border
+              Width="24"
+              Height="24"
+              Margin="0,0,1,5"
+              HorizontalAlignment="Right"
+              VerticalAlignment="Bottom"
+              BorderBrush="White"
+              BorderThickness="2"
+              CornerRadius="12"
+              Background="#63B746">
+            <TextBlock
+                Margin="0,-3,0,0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                FontSize="20"
+                FontWeight="Bold"
+                Foreground="White"
+                Text="›" />
+          </Border>
+        </Grid>
+
+        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="-3">
+          <TextBlock FontSize="25" Foreground="#003399" Text="Remote Desktop" />
+          <TextBlock FontSize="31" FontWeight="Bold" Foreground="#003399" Text="Connection" />
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <TabControl Grid.Row="1" Margin="10,8,10,0">
+      <TabItem Header="General">
+        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+          <StackPanel Margin="10,14,10,8" Spacing="18">
+            <Border BorderBrush="#C9C9C9" BorderThickness="1" Padding="18,16">
+              <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="92,*" RowSpacing="12">
+                <TextBlock
+                    Grid.ColumnSpan="2"
+                    Margin="-8,-27,0,4"
+                    Padding="5,0"
+                    HorizontalAlignment="Left"
+                    Background="#F5F5F5"
+                    FontSize="14"
+                    Text="Logon settings" />
+
+                <TextBlock
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Margin="0,0,0,2"
+                    FontSize="15"
+                    Text="Enter the name of the remote computer." />
+
+                <TextBlock Grid.Row="2" VerticalAlignment="Center" Text="Computer:" />
+                <TextBox
+                    x:Name="HostNameTextBox"
+                    Grid.Row="2"
+                    Grid.Column="1"
+                    AutomationProperties.AutomationId="HostNameTextBox"
+                    Text="it-help-dc"
+                    PlaceholderText="server.example.com" />
+
+                <TextBlock Grid.Row="3" VerticalAlignment="Center" Text="User name:" />
+                <TextBox
+                    x:Name="UserNameTextBox"
+                    Grid.Row="3"
+                    Grid.Column="1"
+                    AutomationProperties.AutomationId="UserNameTextBox"
+                    PlaceholderText="username" />
+
+                <TextBlock Grid.Row="4" VerticalAlignment="Center" Text="Password:" />
+                <local:PasswordTextBox
+                    x:Name="PasswordTextBox"
+                    Grid.Row="4"
+                    Grid.Column="1"
+                    PasswordChar="●"
+                    PlaceholderText="password" />
+
+                <TextBlock Grid.Row="5" VerticalAlignment="Center" Text="Domain:" />
+                <TextBox
+                    x:Name="DomainTextBox"
+                    Grid.Row="5"
+                    Grid.Column="1"
+                    AutomationProperties.AutomationId="DomainTextBox"
+                    PlaceholderText="optional" />
+              </Grid>
+            </Border>
+
+            <Border BorderBrush="#C9C9C9" BorderThickness="1" Padding="18,16">
+              <StackPanel Spacing="8">
+                <TextBlock
+                    Margin="-8,-27,0,4"
+                    Padding="5,0"
+                    HorizontalAlignment="Left"
+                    Background="#F5F5F5"
+                    FontSize="14"
+                    Text="Connection settings" />
+                <TextBlock
+                    Text="These settings are kept in memory for this connection only. The password is cleared from the dialog immediately after Connect is selected."
+                    TextWrapping="Wrap" />
+              </StackPanel>
+            </Border>
+          </StackPanel>
+        </ScrollViewer>
+      </TabItem>
+
+      <TabItem Header="Display">
+        <StackPanel Margin="22,22" Spacing="12">
+          <TextBlock FontSize="16" FontWeight="SemiBold" Text="Display configuration" />
+          <TextBlock
+              Text="Choose the remote desktop resolution. The session is scaled to fit the Avalonia window."
+              TextWrapping="Wrap" />
+          <TextBlock Margin="0,10,0,0" Text="Remote desktop size:" />
+          <ComboBox
+              x:Name="ResolutionComboBox"
+              AutomationProperties.AutomationId="ResolutionComboBox"
+              SelectedIndex="0">
+            <ComboBoxItem Content="Fit the session window" />
+            <ComboBoxItem Content="1024 × 768" />
+            <ComboBoxItem Content="1280 × 720" />
+            <ComboBoxItem Content="1600 × 900" />
+            <ComboBoxItem Content="1920 × 1080" />
+          </ComboBox>
+          <TextBlock
+              Margin="0,10,0,0"
+              Foreground="#666666"
+              Text="Color depth: Highest quality (32 bit)"
+              TextWrapping="Wrap" />
+        </StackPanel>
+      </TabItem>
+    </TabControl>
+
+    <Grid Grid.Row="2" Margin="20,16" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
+      <TextBlock
+          x:Name="ValidationTextBlock"
+          VerticalAlignment="Center"
+          AutomationProperties.AutomationId="ValidationTextBlock"
+          Foreground="#B00020"
+          TextWrapping="Wrap" />
+      <Button
+          x:Name="ConnectButton"
+          Grid.Column="1"
+          MinWidth="110"
+          AutomationProperties.AutomationId="ConnectButton"
+          Click="OnConnectClicked"
+          Content="Connect"
+          IsDefault="True" />
+      <Button
+          Grid.Column="2"
+          MinWidth="90"
+          Click="OnCancelClicked"
+          Content="Cancel"
+          IsCancel="True" />
+    </Grid>
+  </Grid>
+</Window>

--- a/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml.cs
@@ -1,0 +1,104 @@
+using Avalonia.Controls;
+using Devolutions.MsRdpEx.Avalonia;
+using Avalonia.Interactivity;
+
+namespace MsRdpEx_AvaloniaApp;
+
+public sealed partial class ConnectionDialog : Window
+{
+    private int customResolutionIndex = -1;
+    private int customDesktopWidth;
+    private int customDesktopHeight;
+    private string rdpFileContents = string.Empty;
+
+    public ConnectionDialog()
+    {
+        InitializeComponent();
+        Opened += (_, _) =>
+        {
+            HostNameTextBox.Focus();
+            HostNameTextBox.SelectAll();
+        };
+    }
+
+    internal ConnectionDialog(RdpLaunchOptions options) : this()
+    {
+        if (!string.IsNullOrWhiteSpace(options.HostName))
+            HostNameTextBox.Text = options.HostName;
+
+        UserNameTextBox.Text = options.UserName;
+        PasswordTextBox.Text = options.Password;
+        DomainTextBox.Text = options.Domain;
+        rdpFileContents = options.RdpFileContents;
+        ValidationTextBlock.Text = options.Error ?? string.Empty;
+
+        int resolutionIndex = (options.DesktopWidth, options.DesktopHeight) switch
+        {
+            (1024, 768) => 1,
+            (1280, 720) => 2,
+            (1600, 900) => 3,
+            (1920, 1080) => 4,
+            _ => 0
+        };
+
+        if (resolutionIndex == 0 && options.DesktopWidth > 0 && options.DesktopHeight > 0)
+        {
+            customDesktopWidth = options.DesktopWidth;
+            customDesktopHeight = options.DesktopHeight;
+            ResolutionComboBox.Items.Add(new ComboBoxItem
+            {
+                Content = $"{customDesktopWidth} × {customDesktopHeight} (from RDP file)"
+            });
+            customResolutionIndex = ResolutionComboBox.ItemCount - 1;
+            resolutionIndex = customResolutionIndex;
+        }
+
+        ResolutionComboBox.SelectedIndex = resolutionIndex;
+    }
+
+    public event Action<RdpConnectionSettings>? ConnectionRequested;
+
+    private void OnConnectClicked(object? sender, RoutedEventArgs e)
+    {
+        string hostName = HostNameTextBox.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(hostName))
+        {
+            ValidationTextBlock.Text = "Enter the name of the remote computer.";
+            HostNameTextBox.Focus();
+            return;
+        }
+
+        string password = PasswordTextBox.Text ?? string.Empty;
+        (int desktopWidth, int desktopHeight) = ResolutionComboBox.SelectedIndex switch
+        {
+            1 => (1024, 768),
+            2 => (1280, 720),
+            3 => (1600, 900),
+            4 => (1920, 1080),
+            var index when index == customResolutionIndex => (customDesktopWidth, customDesktopHeight),
+            _ => (0, 0)
+        };
+
+        RdpConnectionSettings settings = new(
+            hostName,
+            UserNameTextBox.Text?.Trim() ?? string.Empty,
+            password,
+            DomainTextBox.Text?.Trim() ?? string.Empty,
+            desktopWidth,
+            desktopHeight,
+            rdpFileContents);
+
+        // Do not retain the visible password after handing it to the session window.
+        PasswordTextBox.Text = string.Empty;
+        password = string.Empty;
+        ValidationTextBlock.Text = string.Empty;
+        ConnectButton.IsEnabled = false;
+        ConnectionRequested?.Invoke(settings);
+    }
+
+    private void OnCancelClicked(object? sender, RoutedEventArgs e)
+    {
+        PasswordTextBox.Text = string.Empty;
+        Close();
+    }
+}

--- a/dotnet/MsRdpEx_AvaloniaApp/MainWindow.axaml
+++ b/dotnet/MsRdpEx_AvaloniaApp/MainWindow.axaml
@@ -1,0 +1,13 @@
+<Window
+    x:Class="MsRdpEx_AvaloniaApp.MainWindow"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rdp="using:Devolutions.MsRdpEx.Avalonia"
+    Title="MsRdpEx Avalonia RDP"
+    Width="1280"
+    Height="820"
+    MinWidth="800"
+    MinHeight="520"
+    Background="Black">
+  <rdp:RdpClientView x:Name="RdpHost" />
+</Window>

--- a/dotnet/MsRdpEx_AvaloniaApp/MainWindow.axaml.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/MainWindow.axaml.cs
@@ -1,0 +1,63 @@
+using Avalonia.Controls;
+using Devolutions.MsRdpEx.Avalonia;
+
+namespace MsRdpEx_AvaloniaApp;
+
+public sealed partial class MainWindow : Window
+{
+    private RdpConnectionSettings? pendingSettings;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    internal MainWindow(RdpConnectionSettings settings, RdpLaunchOptions? launchOptions = null) : this()
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        pendingSettings = settings;
+        if (launchOptions is not null)
+        {
+            RdpHost.ClassId = launchOptions.ClassId;
+            RdpHost.AxName = launchOptions.AxName;
+            RdpHost.RdpExDll = launchOptions.RdpExDll;
+        }
+        Title = $"{settings.HostName} - MsRdpEx Avalonia RDP";
+
+        RdpHost.ClientReady += OnClientReady;
+        Closing += OnWindowClosing;
+    }
+
+    private void OnClientReady(object? sender, EventArgs e)
+    {
+        if (pendingSettings is null)
+            return;
+
+        RdpConnectionSettings settings = pendingSettings;
+        pendingSettings = null;
+
+        try
+        {
+            RdpHost.Connect(settings);
+        }
+        catch (Exception exception)
+        {
+            Title = $"{settings.HostName} - Connection failed: {exception.Message}";
+        }
+    }
+
+    private void OnWindowClosing(object? sender, WindowClosingEventArgs e)
+    {
+        pendingSettings = null;
+
+        try
+        {
+            RdpHost.Dispose();
+        }
+        catch
+        {
+            // The native session engine may already be in its teardown path.
+        }
+    }
+}

--- a/dotnet/MsRdpEx_AvaloniaApp/MsRdpEx_AvaloniaApp.csproj
+++ b/dotnet/MsRdpEx_AvaloniaApp/MsRdpEx_AvaloniaApp.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>x64</PlatformTarget>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Devolutions.MsRdpEx.Avalonia\Devolutions.MsRdpEx.Avalonia.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('..\..\build-x64\Release\MsRdpEx.dll')">
+    <None Include="..\..\build-x64\Release\MsRdpEx.dll"
+          Link="MsRdpEx.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/dotnet/MsRdpEx_AvaloniaApp/PasswordTextBox.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/PasswordTextBox.cs
@@ -1,4 +1,5 @@
 using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
 using Avalonia.Controls;
 
 namespace MsRdpEx_AvaloniaApp;
@@ -13,6 +14,32 @@ public sealed class PasswordTextBox : TextBox
 
     protected override AutomationPeer OnCreateAutomationPeer()
     {
-        return new NoneAutomationPeer(this);
+        return new PasswordTextBoxAutomationPeer(this);
+    }
+
+    private sealed class PasswordTextBoxAutomationPeer(PasswordTextBox owner)
+        : ControlAutomationPeer(owner), IValueProvider
+    {
+        bool IValueProvider.IsReadOnly => owner.IsReadOnly;
+
+        string IValueProvider.Value => string.Empty;
+
+        void IValueProvider.SetValue(string value)
+        {
+            if (owner.IsReadOnly)
+                throw new InvalidOperationException("The password field is read-only.");
+
+            owner.Text = value;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Edit;
+        }
+
+        protected override string GetClassNameCore()
+        {
+            return nameof(TextBox);
+        }
     }
 }

--- a/dotnet/MsRdpEx_AvaloniaApp/PasswordTextBox.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/PasswordTextBox.cs
@@ -1,0 +1,18 @@
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+
+namespace MsRdpEx_AvaloniaApp;
+
+/// <summary>
+/// Prevents password text from being exposed through the UI Automation value
+/// provider while retaining the standard Avalonia TextBox editing behavior.
+/// </summary>
+public sealed class PasswordTextBox : TextBox
+{
+    protected override Type StyleKeyOverride => typeof(TextBox);
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new NoneAutomationPeer(this);
+    }
+}

--- a/dotnet/MsRdpEx_AvaloniaApp/Program.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/Program.cs
@@ -1,0 +1,20 @@
+using Avalonia;
+
+namespace MsRdpEx_AvaloniaApp;
+
+internal static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        return AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+    }
+}

--- a/dotnet/MsRdpEx_AvaloniaApp/README.md
+++ b/dotnet/MsRdpEx_AvaloniaApp/README.md
@@ -1,0 +1,71 @@
+# MsRdpEx Avalonia sample
+
+This Windows-only sample renders an RDP session into an Avalonia 12 control
+without placing a native HWND in the Avalonia visual tree and without using
+Windows Forms or WPF.
+
+`RdpClientView` comes from the reusable `Devolutions.MsRdpEx.Avalonia` project
+and is a regular Avalonia `UserControl`. MsRdpEx activates the Microsoft RDP
+ActiveX control through its own OLE client site and in-place site in an
+off-screen HWND; it does not use Windows Forms `AxHost` or ATL's ActiveX host.
+MsRdpEx mirrors the session output into a top-down 32-bit DIB, and the control
+copies that backing buffer into an Avalonia `WriteableBitmap`. Pointer, wheel,
+and keyboard input are mapped back to the RDP input window.
+
+`build-x64/Release/MsRdpEx.dll` is required and is copied beside the sample
+executable automatically when the project builds.
+
+## Run
+
+From the repository root:
+
+```powershell
+cmake --build .\build-x64 --config Release
+dotnet run --project .\dotnet\MsRdpEx_AvaloniaApp\MsRdpEx_AvaloniaApp.csproj
+```
+
+The app opens with a connection-settings dialog modeled after the Microsoft
+Remote Desktop Connection dialog. Enter the destination host, user name,
+password, and optional domain, choose an optional desktop resolution, then
+select **Connect**. A separate native Avalonia session window opens and renders
+the RDP backing bitmap. The password is passed directly to the RDP control,
+cleared from the dialog, and never written to disk by the sample.
+
+The session window contains only the edge-to-edge RDP surface. Use the standard
+window Close button to disconnect and close the session.
+
+The default **Fit the session window** display mode uses the Avalonia canvas's
+physical pixel size for the initial desktop. Resizing the window sends a
+debounced dynamic-resolution update after login. Explicit resolutions selected
+on the Display tab remain fixed and are only scaled for presentation.
+
+## Command line and environment
+
+The dialog accepts the same `RDP_HOSTNAME`, `RDP_USERNAME`, `RDP_PASSWORD`, and
+`RDP_FILENAME` environment variables as `MsRdpEx_App`. `RDP_DOMAIN` is also
+supported. Command-line values override the environment and can use either
+long option names or the common RDP aliases:
+
+```powershell
+MsRdpEx_AvaloniaApp.exe --hostname it-help-dc --username administrator --domain CONTOSO
+MsRdpEx_AvaloniaApp.exe /v:it-help-dc /u:administrator /d:CONTOSO
+MsRdpEx_AvaloniaApp.exe --filename .\connection.rdp
+MsRdpEx_AvaloniaApp.exe .\connection.rdp
+```
+
+Supported long names are `--hostname`, `--username`, `--password`, `--domain`,
+and `--filename`; their `--RDP_*` forms are accepted as well. Supplying a
+password on a command line can expose it through process inspection, so the
+password field or `RDP_PASSWORD` should be preferred.
+
+## Notes
+
+- The sample targets x64 Windows and Avalonia 12.1.1.
+- The sample references the reusable `Devolutions.MsRdpEx.Avalonia` project;
+  other Avalonia applications can embed the same `RdpClientView` control.
+- The visible surface is fully Avalonia-rendered, so Avalonia overlays and
+  transforms can compose with it normally.
+- The sample polls the MsRdpEx shadow bitmap at approximately 30 frames per
+  second. A production control may want dirty-region signaling instead.
+- Server certificate and credential prompts are owned by the Microsoft RDP
+  control and may appear as separate native dialogs.

--- a/dotnet/MsRdpEx_AvaloniaApp/RdpLaunchOptions.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/RdpLaunchOptions.cs
@@ -1,0 +1,238 @@
+using Devolutions.MsRdpEx.Avalonia;
+
+namespace MsRdpEx_AvaloniaApp;
+
+internal sealed record RdpLaunchOptions(
+    string HostName,
+    string UserName,
+    string Password,
+    string Domain,
+    int DesktopWidth,
+    int DesktopHeight,
+    string RdpFileContents,
+    string? Error,
+    Guid ClassId,
+    string AxName,
+    string? RdpExDll)
+{
+    public static RdpLaunchOptions Parse(IReadOnlyList<string> arguments)
+    {
+        Dictionary<string, string> commandLine = new(StringComparer.OrdinalIgnoreCase);
+        string? rdpFileName = null;
+        string? error = null;
+
+        for (int index = 0; index < arguments.Count; index++)
+        {
+            string argument = arguments[index];
+            if (!TrySplitOption(argument, out string name, out string? value))
+            {
+                if (Path.GetExtension(argument).Equals(".rdp", StringComparison.OrdinalIgnoreCase) && rdpFileName is null)
+                {
+                    rdpFileName = argument;
+                    continue;
+                }
+
+                error = $"Unknown command-line argument: {argument}";
+                break;
+            }
+
+            string normalizedName = NormalizeOptionName(name);
+            if (value is null)
+            {
+                if (++index >= arguments.Count)
+                {
+                    error = $"Missing value for command-line option: {argument}";
+                    break;
+                }
+
+                value = arguments[index];
+            }
+
+            if (!IsSupportedOption(normalizedName))
+            {
+                error = $"Unknown command-line option: {argument}";
+                break;
+            }
+
+            commandLine[normalizedName] = value;
+        }
+
+        string environmentHost = Environment.GetEnvironmentVariable("RDP_HOSTNAME") ?? string.Empty;
+        string environmentUser = Environment.GetEnvironmentVariable("RDP_USERNAME") ?? string.Empty;
+        string environmentPassword = Environment.GetEnvironmentVariable("RDP_PASSWORD") ?? string.Empty;
+        string environmentDomain = Environment.GetEnvironmentVariable("RDP_DOMAIN") ?? string.Empty;
+        string? configuredClassId = GetOption(commandLine, "class-id")
+            ?? Environment.GetEnvironmentVariable("RDP_CLASS_ID");
+        string axName = GetOption(commandLine, "ax-name")
+            ?? Environment.GetEnvironmentVariable("RDP_AXNAME")
+            ?? "mstsc";
+        string? rdpExDll = GetOption(commandLine, "rdpex-dll")
+            ?? Environment.GetEnvironmentVariable("MSRDPEX_DLL");
+
+        Guid classId = RdpClientView.DefaultClassId;
+        if (!string.IsNullOrWhiteSpace(configuredClassId) &&
+            !Guid.TryParse(configuredClassId, out classId))
+        {
+            error ??= $"Invalid RDP ActiveX class identifier: {configuredClassId}";
+            classId = RdpClientView.DefaultClassId;
+        }
+
+        rdpFileName = GetOption(commandLine, "filename")
+            ?? Environment.GetEnvironmentVariable("RDP_FILENAME")
+            ?? rdpFileName;
+
+        RdpFileValues rdpFile = RdpFileValues.Empty;
+        if (!string.IsNullOrWhiteSpace(rdpFileName))
+        {
+            try
+            {
+                rdpFile = ReadRdpFile(rdpFileName);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                error ??= $"Unable to open RDP file '{rdpFileName}': {exception.Message}";
+            }
+        }
+
+        string hostName = GetOption(commandLine, "hostname") ?? rdpFile.HostName ?? environmentHost;
+        string userName = GetOption(commandLine, "username") ?? rdpFile.UserName ?? environmentUser;
+        string password = GetOption(commandLine, "password") ?? environmentPassword;
+        string domain = GetOption(commandLine, "domain") ?? rdpFile.Domain ?? environmentDomain;
+
+        int desktopWidth = rdpFile.DynamicResolution ? 0 : rdpFile.DesktopWidth;
+        int desktopHeight = rdpFile.DynamicResolution ? 0 : rdpFile.DesktopHeight;
+
+        return new RdpLaunchOptions(
+            hostName,
+            userName,
+            password,
+            domain,
+            desktopWidth,
+            desktopHeight,
+            rdpFile.Contents,
+            error,
+            classId,
+            axName,
+            rdpExDll);
+    }
+
+    private static bool TrySplitOption(string argument, out string name, out string? value)
+    {
+        name = string.Empty;
+        value = null;
+
+        int prefixLength = argument.StartsWith("--", StringComparison.Ordinal) ? 2
+            : argument.StartsWith("-", StringComparison.Ordinal) || argument.StartsWith("/", StringComparison.Ordinal) ? 1
+            : 0;
+        if (prefixLength == 0 || argument.Length <= prefixLength)
+            return false;
+
+        string option = argument[prefixLength..];
+        int separator = option.IndexOfAny(['=', ':']);
+        if (separator < 0)
+        {
+            name = option;
+            return true;
+        }
+
+        name = option[..separator];
+        value = option[(separator + 1)..];
+        return true;
+    }
+
+    private static string NormalizeOptionName(string name)
+    {
+        string normalized = name.Trim().Replace('_', '-').ToLowerInvariant();
+        return normalized switch
+        {
+            "rdp-hostname" or "server" or "v" => "hostname",
+            "rdp-username" or "user" or "u" => "username",
+            "rdp-password" or "p" => "password",
+            "rdp-domain" or "d" => "domain",
+            "rdp-filename" or "rdp-file" or "file" => "filename",
+            "clsid" or "classid" => "class-id",
+            "axname" => "ax-name",
+            "rdpex" or "rdpex-dll-path" => "rdpex-dll",
+            _ => normalized
+        };
+    }
+
+    private static bool IsSupportedOption(string name)
+    {
+        return name is "hostname" or "username" or "password" or "domain" or "filename" or
+            "class-id" or "ax-name" or "rdpex-dll";
+    }
+
+    private static string? GetOption(Dictionary<string, string> options, string name)
+    {
+        return options.TryGetValue(name, out string? value) ? value : null;
+    }
+
+    private static RdpFileValues ReadRdpFile(string fileName)
+    {
+        string contents = File.ReadAllText(fileName);
+        string? hostName = null;
+        string? userName = null;
+        string? domain = null;
+        int desktopWidth = 0;
+        int desktopHeight = 0;
+        bool dynamicResolution = false;
+
+        foreach (string line in contents.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            int firstColon = line.IndexOf(':');
+            if (firstColon <= 0 || firstColon + 2 >= line.Length || line[firstColon + 2] != ':')
+                continue;
+
+            string name = line[..firstColon].Trim();
+            char type = line[firstColon + 1];
+            string value = line[(firstColon + 3)..];
+
+            if (type == 's')
+            {
+                switch (name.ToLowerInvariant())
+                {
+                    case "full address":
+                        hostName = value;
+                        break;
+                    case "username":
+                        userName = value;
+                        break;
+                    case "domain":
+                        domain = value;
+                        break;
+                }
+            }
+            else if (type == 'i' && int.TryParse(value, out int integerValue))
+            {
+                switch (name.ToLowerInvariant())
+                {
+                    case "desktopwidth":
+                        desktopWidth = integerValue;
+                        break;
+                    case "desktopheight":
+                        desktopHeight = integerValue;
+                        break;
+                    case "dynamic resolution":
+                        dynamicResolution = integerValue != 0;
+                        break;
+                }
+            }
+        }
+
+        return new RdpFileValues(
+            contents, hostName, userName, domain, desktopWidth, desktopHeight, dynamicResolution);
+    }
+
+    private sealed record RdpFileValues(
+        string Contents,
+        string? HostName,
+        string? UserName,
+        string? Domain,
+        int DesktopWidth,
+        int DesktopHeight,
+        bool DynamicResolution)
+    {
+        public static RdpFileValues Empty { get; } = new(string.Empty, null, null, null, 0, 0, false);
+    }
+}

--- a/dotnet/MsRdpEx_AvaloniaApp/RdpLaunchOptions.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/RdpLaunchOptions.cs
@@ -17,6 +17,21 @@ internal sealed record RdpLaunchOptions(
 {
     public static RdpLaunchOptions Parse(IReadOnlyList<string> arguments)
     {
+        return Parse(
+            arguments,
+            Environment.GetEnvironmentVariable,
+            File.ReadAllText);
+    }
+
+    internal static RdpLaunchOptions Parse(
+        IReadOnlyList<string> arguments,
+        Func<string, string?> getEnvironmentVariable,
+        Func<string, string> readFile)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(getEnvironmentVariable);
+        ArgumentNullException.ThrowIfNull(readFile);
+
         Dictionary<string, string> commandLine = new(StringComparer.OrdinalIgnoreCase);
         string? rdpFileName = null;
         string? error = null;
@@ -39,7 +54,8 @@ internal sealed record RdpLaunchOptions(
             string normalizedName = NormalizeOptionName(name);
             if (value is null)
             {
-                if (++index >= arguments.Count)
+                if (++index >= arguments.Count ||
+                    TrySplitOption(arguments[index], out _, out _))
                 {
                     error = $"Missing value for command-line option: {argument}";
                     break;
@@ -57,17 +73,17 @@ internal sealed record RdpLaunchOptions(
             commandLine[normalizedName] = value;
         }
 
-        string environmentHost = Environment.GetEnvironmentVariable("RDP_HOSTNAME") ?? string.Empty;
-        string environmentUser = Environment.GetEnvironmentVariable("RDP_USERNAME") ?? string.Empty;
-        string environmentPassword = Environment.GetEnvironmentVariable("RDP_PASSWORD") ?? string.Empty;
-        string environmentDomain = Environment.GetEnvironmentVariable("RDP_DOMAIN") ?? string.Empty;
+        string environmentHost = getEnvironmentVariable("RDP_HOSTNAME") ?? string.Empty;
+        string environmentUser = getEnvironmentVariable("RDP_USERNAME") ?? string.Empty;
+        string environmentPassword = getEnvironmentVariable("RDP_PASSWORD") ?? string.Empty;
+        string environmentDomain = getEnvironmentVariable("RDP_DOMAIN") ?? string.Empty;
         string? configuredClassId = GetOption(commandLine, "class-id")
-            ?? Environment.GetEnvironmentVariable("RDP_CLASS_ID");
+            ?? getEnvironmentVariable("RDP_CLASS_ID");
         string axName = GetOption(commandLine, "ax-name")
-            ?? Environment.GetEnvironmentVariable("RDP_AXNAME")
+            ?? getEnvironmentVariable("RDP_AXNAME")
             ?? "mstsc";
         string? rdpExDll = GetOption(commandLine, "rdpex-dll")
-            ?? Environment.GetEnvironmentVariable("MSRDPEX_DLL");
+            ?? getEnvironmentVariable("MSRDPEX_DLL");
 
         Guid classId = RdpClientView.DefaultClassId;
         if (!string.IsNullOrWhiteSpace(configuredClassId) &&
@@ -78,7 +94,7 @@ internal sealed record RdpLaunchOptions(
         }
 
         rdpFileName = GetOption(commandLine, "filename")
-            ?? Environment.GetEnvironmentVariable("RDP_FILENAME")
+            ?? getEnvironmentVariable("RDP_FILENAME")
             ?? rdpFileName;
 
         RdpFileValues rdpFile = RdpFileValues.Empty;
@@ -86,7 +102,7 @@ internal sealed record RdpLaunchOptions(
         {
             try
             {
-                rdpFile = ReadRdpFile(rdpFileName);
+                rdpFile = ReadRdpFile(rdpFileName, readFile);
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
             {
@@ -168,9 +184,11 @@ internal sealed record RdpLaunchOptions(
         return options.TryGetValue(name, out string? value) ? value : null;
     }
 
-    private static RdpFileValues ReadRdpFile(string fileName)
+    private static RdpFileValues ReadRdpFile(
+        string fileName,
+        Func<string, string> readFile)
     {
-        string contents = File.ReadAllText(fileName);
+        string contents = readFile(fileName);
         string? hostName = null;
         string? userName = null;
         string? domain = null;

--- a/dotnet/MsRdpEx_AvaloniaApp/app.manifest
+++ b/dotnet/MsRdpEx_AvaloniaApp/app.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MsRdpEx_AvaloniaApp" />
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/dotnet/MsRdpEx_Test/MsRdpEx_Test.csproj
+++ b/dotnet/MsRdpEx_Test/MsRdpEx_Test.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia" Version="12.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" ExcludeAssets="compile" PrivateAssets="all"/>
@@ -25,8 +26,13 @@
   <ItemGroup>
     <ProjectReference Include="..\AxInterop.MSTSCLib\AxInterop.MSTSCLib.csproj" />
     <ProjectReference Include="..\Devolutions.MsRdpEx\Devolutions.MsRdpEx.csproj" />
+    <ProjectReference Include="..\Devolutions.MsRdpEx.Avalonia\Devolutions.MsRdpEx.Avalonia.csproj" />
     <ProjectReference Include="..\Interop.MSTSCLib.Generated\Interop.MSTSCLib.Generated.csproj" Aliases="global,ModernInterop" />
     <ProjectReference Include="..\Interop.MSTSCLib.Generated.WinForms\Interop.MSTSCLib.Generated.WinForms.csproj" Aliases="GeneratedWinFormsHost" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MsRdpEx_AvaloniaApp\RdpLaunchOptions.cs" Link="RdpLaunchOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/MsRdpEx_Test/RdpLaunchOptions.cs
+++ b/dotnet/MsRdpEx_Test/RdpLaunchOptions.cs
@@ -1,0 +1,137 @@
+namespace MsRdpEx_AvaloniaApp;
+
+public sealed class RdpLaunchOptionsTests
+{
+    private static readonly Func<string, string?> EmptyEnvironment = _ => null;
+
+    [Fact]
+    public void ParseSupportsAliasesAndInlineValues()
+    {
+        Guid classId = Guid.NewGuid();
+        RdpLaunchOptions options = RdpLaunchOptions.Parse(
+            [
+                "/v:server.example.com",
+                "--user", "alice",
+                "-p=sample-password",
+                "/d:CONTOSO",
+                $"--clsid={classId}",
+                "--axname", "msrdc",
+                "--rdpex-dll-path", "custom.dll"
+            ],
+            EmptyEnvironment,
+            _ => throw new InvalidOperationException());
+
+        Assert.Null(options.Error);
+        Assert.Equal("server.example.com", options.HostName);
+        Assert.Equal("alice", options.UserName);
+        Assert.Equal("sample-password", options.Password);
+        Assert.Equal("CONTOSO", options.Domain);
+        Assert.Equal(classId, options.ClassId);
+        Assert.Equal("msrdc", options.AxName);
+        Assert.Equal("custom.dll", options.RdpExDll);
+    }
+
+    [Fact]
+    public void ParseReportsMissingSeparateValue()
+    {
+        RdpLaunchOptions atEnd = RdpLaunchOptions.Parse(
+            ["--hostname"], EmptyEnvironment, _ => string.Empty);
+        RdpLaunchOptions beforeOption = RdpLaunchOptions.Parse(
+            ["--hostname", "--username=alice"], EmptyEnvironment, _ => string.Empty);
+
+        Assert.Equal("Missing value for command-line option: --hostname", atEnd.Error);
+        Assert.Equal("Missing value for command-line option: --hostname", beforeOption.Error);
+    }
+
+    [Fact]
+    public void CommandLineOverridesRdpFileAndEnvironment()
+    {
+        const string rdpContents = """
+            full address:s:file-host
+            username:s:file-user
+            domain:s:FILE-DOMAIN
+            desktopwidth:i:1600
+            desktopheight:i:900
+            """;
+        Dictionary<string, string> environment = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["RDP_HOSTNAME"] = "environment-host",
+            ["RDP_USERNAME"] = "environment-user",
+            ["RDP_PASSWORD"] = "environment-password",
+            ["RDP_DOMAIN"] = "ENVIRONMENT-DOMAIN"
+        };
+
+        RdpLaunchOptions options = RdpLaunchOptions.Parse(
+            ["settings.rdp", "--hostname=command-host", "--password", "command-password"],
+            name => environment.GetValueOrDefault(name),
+            fileName => fileName == "settings.rdp"
+                ? rdpContents
+                : throw new FileNotFoundException(fileName));
+
+        Assert.Null(options.Error);
+        Assert.Equal("command-host", options.HostName);
+        Assert.Equal("file-user", options.UserName);
+        Assert.Equal("command-password", options.Password);
+        Assert.Equal("FILE-DOMAIN", options.Domain);
+        Assert.Equal(1600, options.DesktopWidth);
+        Assert.Equal(900, options.DesktopHeight);
+        Assert.Equal(rdpContents, options.RdpFileContents);
+    }
+
+    [Fact]
+    public void ExplicitRdpFileOverridesEnvironmentAndPositionalFiles()
+    {
+        Dictionary<string, string> environment = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["RDP_FILENAME"] = "environment.rdp"
+        };
+
+        RdpLaunchOptions options = RdpLaunchOptions.Parse(
+            ["positional.rdp", "--file=command.rdp"],
+            name => environment.GetValueOrDefault(name),
+            fileName => $"full address:s:{fileName}");
+
+        Assert.Null(options.Error);
+        Assert.Equal("command.rdp", options.HostName);
+    }
+
+    [Fact]
+    public void DynamicResolutionOverridesRdpFileDimensions()
+    {
+        const string rdpContents = """
+            full address:s:dynamic-host
+            desktopwidth:i:1920
+            desktopheight:i:1080
+            dynamic resolution:i:1
+            """;
+
+        RdpLaunchOptions options = RdpLaunchOptions.Parse(
+            ["dynamic.rdp"], EmptyEnvironment, _ => rdpContents);
+
+        Assert.Null(options.Error);
+        Assert.Equal(0, options.DesktopWidth);
+        Assert.Equal(0, options.DesktopHeight);
+    }
+
+    [Fact]
+    public void InvalidClassIdReturnsDefaultAndError()
+    {
+        RdpLaunchOptions options = RdpLaunchOptions.Parse(
+            ["--class-id=not-a-guid"], EmptyEnvironment, _ => string.Empty);
+
+        Assert.Equal("Invalid RDP ActiveX class identifier: not-a-guid", options.Error);
+        Assert.Equal(Devolutions.MsRdpEx.Avalonia.RdpClientView.DefaultClassId, options.ClassId);
+    }
+
+    [Fact]
+    public void UnknownArgumentsReturnAnError()
+    {
+        RdpLaunchOptions option = RdpLaunchOptions.Parse(
+            ["--unsupported=value"], EmptyEnvironment, _ => string.Empty);
+        RdpLaunchOptions argument = RdpLaunchOptions.Parse(
+            ["notes.txt"], EmptyEnvironment, _ => string.Empty);
+
+        Assert.Equal("Unknown command-line option: --unsupported=value", option.Error);
+        Assert.Equal("Unknown command-line argument: notes.txt", argument.Error);
+    }
+}

--- a/include/MsRdpEx/OutputMirror.h
+++ b/include/MsRdpEx/OutputMirror.h
@@ -16,6 +16,9 @@ HDC MsRdpEx_OutputMirror_GetShadowDC(MsRdpEx_OutputMirror* ctx);
 
 void MsRdpEx_OutputMirror_SetFrameSize(MsRdpEx_OutputMirror* ctx, uint32_t frameWidth, uint32_t frameHeight);
 void MsRdpEx_OutputMirror_GetFrameSize(MsRdpEx_OutputMirror* ctx, uint32_t* frameWidth, uint32_t* frameHeight);
+// Monotonically changes after a completed shadow-bitmap update. Consumers can
+// avoid copying the full DIB while the remote desktop is unchanged.
+uint32_t MsRdpEx_OutputMirror_GetFrameVersion(MsRdpEx_OutputMirror* ctx);
 
 bool MsRdpEx_OutputMirror_DumpFrame(MsRdpEx_OutputMirror* ctx);
 

--- a/include/MsRdpEx/RdpInstance.h
+++ b/include/MsRdpEx/RdpInstance.h
@@ -53,6 +53,40 @@ extern "C" {
 #endif
 
 typedef struct _MsRdpEx_InstanceManager MsRdpEx_InstanceManager;
+typedef struct _MsRdpEx_OutputMirrorCapture MsRdpEx_OutputMirrorCapture;
+
+/*
+ * Creates a capture-only native view of an IMsRdpExInstance. Create and
+ * Release must run on the COM apartment/thread that owns pInstance. The
+ * GetFrameVersion, GetShadowBitmap, Lock, and Unlock operations are explicitly
+ * safe to call from one background capture thread while the handle remains
+ * alive. A successful GetShadowBitmap must precede Lock; after Lock, call it
+ * again to obtain the current DIB and always pair the lock with Unlock.
+ */
+HRESULT STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Create(
+    IUnknown* pInstance,
+    MsRdpEx_OutputMirrorCapture** ppCapture);
+
+uint32_t STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_GetFrameVersion(
+    MsRdpEx_OutputMirrorCapture* pCapture);
+
+bool STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_GetShadowBitmap(
+    MsRdpEx_OutputMirrorCapture* pCapture,
+    HDC* phDC,
+    HBITMAP* phBitmap,
+    uint8_t** pBitmapData,
+    uint32_t* pBitmapWidth,
+    uint32_t* pBitmapHeight,
+    uint32_t* pBitmapStep);
+
+void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Lock(
+    MsRdpEx_OutputMirrorCapture* pCapture);
+
+void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Unlock(
+    MsRdpEx_OutputMirrorCapture* pCapture);
+
+void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Release(
+    MsRdpEx_OutputMirrorCapture* pCapture);
 
 bool MsRdpEx_InstanceManager_Add(CMsRdpExInstance* instance);
 bool MsRdpEx_InstanceManager_Remove(CMsRdpExInstance* instance);

--- a/include/MsRdpEx/RdpOleHost.h
+++ b/include/MsRdpEx/RdpOleHost.h
@@ -1,0 +1,45 @@
+#ifndef MSRDPEX_RDP_OLE_HOST_H
+#define MSRDPEX_RDP_OLE_HOST_H
+
+#include <MsRdpEx/MsRdpEx.h>
+
+#include <oleidl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _MsRdpEx_RdpOleHost MsRdpEx_RdpOleHost;
+
+/*
+ * Activates an OLE control in-place in hWnd and owns the OLE client-site and
+ * in-place-site lifetime. The caller retains ownership of pControl and hWnd.
+ * Release the returned opaque host with MsRdpEx_RdpOleHost_Release before the
+ * window is destroyed.
+ */
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_Attach(
+    IUnknown* pControl,
+    HWND hWnd,
+    LPCRECT pBounds,
+    MsRdpEx_RdpOleHost** ppHost);
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetBounds(
+    MsRdpEx_RdpOleHost* pHost,
+    LPCRECT pBounds);
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetActive(
+    MsRdpEx_RdpOleHost* pHost,
+    BOOL active);
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_TranslateAccelerator(
+    MsRdpEx_RdpOleHost* pHost,
+    LPMSG pMsg);
+
+void STDAPICALLTYPE MsRdpEx_RdpOleHost_Release(
+    MsRdpEx_RdpOleHost* pHost);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MSRDPEX_RDP_OLE_HOST_H */

--- a/include/MsRdpEx/RdpOleHost.h
+++ b/include/MsRdpEx/RdpOleHost.h
@@ -15,7 +15,10 @@ typedef struct _MsRdpEx_RdpOleHost MsRdpEx_RdpOleHost;
  * Activates an OLE control in-place in hWnd and owns the OLE client-site and
  * in-place-site lifetime. The caller retains ownership of pControl and hWnd.
  * Release the returned opaque host with MsRdpEx_RdpOleHost_Release before the
- * window is destroyed.
+ * window is destroyed. The caller must initialize OLE on the calling thread
+ * before Attach. The returned host, its HWND, and every host operation are
+ * apartment-bound: call SetBounds, SetActive, TranslateAccelerator, and Release
+ * only from the same thread that called Attach.
  */
 HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_Attach(
     IUnknown* pControl,


### PR DESCRIPTION
This pull request introduces a new Avalonia-based RDP client view, enhances COM hosting infrastructure, and improves thread safety and API surface for output mirroring. The most significant changes are the addition of a reusable Avalonia RDP view, the implementation of a robust OLE hosting layer, and improvements to output mirror concurrency and API. Build system and documentation updates accompany these features.

**Avalonia RDP View Integration:**
- Added a new `Devolutions.MsRdpEx.Avalonia` project and documented its usage, enabling Avalonia 12 applications to embed a bitmap-backed RDP client view (`RdpClientView`) without imposing Avalonia dependencies on WinForms or .NET Framework consumers. (`README.md`, `dotnet/Devolutions.MsRdpEx.Avalonia/Devolutions.MsRdpEx.Avalonia.csproj`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R85) [[2]](diffhunk://#diff-67434d40dd57e9a638daa4777a443afca78c57c7d6d63d2c25a5406b8f69d9aeR1-R22)

**OLE Hosting Infrastructure:**
- Implemented `CRdpOleHost` in `RdpOleHost.cpp`, providing a reusable, self-contained OLE hosting class for ActiveX controls, with attach/detach, activation, and accelerator translation APIs. Corresponding exports were added to the DLL and DEF file. (`dll/AxHost/RdpOleHost.cpp`, `dll/MsRdpEx.def`) [[1]](diffhunk://#diff-83abe31ad54717e40323cd28bebe4656293c34a7b7a252fe3a44175e7a897402R1-R370) [[2]](diffhunk://#diff-39854e5ccc0a3568c64d87ba860acf1e28f5ca14e390fcc32c8bd1f4b1f3c87bR29-R34)
- Extended `CRdpOleClientSite` and `CRdpOleInPlaceSiteEx` to fully implement required OLE interfaces, supporting advanced hosting scenarios and better control integration. (`dll/AxHost/RdpOleSite.h`) [[1]](diffhunk://#diff-8611dce89565ce2960cd469abdf3d6608836bb6bcb14f1afbef2fe1fbc961119L8-R14) [[2]](diffhunk://#diff-8611dce89565ce2960cd469abdf3d6608836bb6bcb14f1afbef2fe1fbc961119R33-R72) [[3]](diffhunk://#diff-8611dce89565ce2960cd469abdf3d6608836bb6bcb14f1afbef2fe1fbc961119R107-R128)

**Output Mirror Enhancements:**
- Made the `captureIndex` field in `MsRdpEx_OutputMirror` atomic for thread safety and added a new API (`MsRdpEx_OutputMirror_GetFrameVersion`) for retrieving the current frame version, using proper atomic operations for increment and read. (`dll/OutputMirror.c`, `dll/MsRdpEx.def`) [[1]](diffhunk://#diff-616a713f0857eb548cb918c22027a1d896e7e639ac1cd10341c84f9bbc46da68L22-R22) [[2]](diffhunk://#diff-616a713f0857eb548cb918c22027a1d896e7e639ac1cd10341c84f9bbc46da68R80-R87) [[3]](diffhunk://#diff-616a713f0857eb548cb918c22027a1d896e7e639ac1cd10341c84f9bbc46da68L107-R115) [[4]](diffhunk://#diff-39854e5ccc0a3568c64d87ba860acf1e28f5ca14e390fcc32c8bd1f4b1f3c87bR29-R34)

**Build System Updates:**
- Integrated the new Avalonia projects and OLE host sources/headers into the build system, and ensured required libraries (like `ole32.lib`) are linked. (`dll/CMakeLists.txt`, `dotnet/CMakeLists.txt`) [[1]](diffhunk://#diff-a174d4a41882d600e50a7aada5b20b472eac19f1e37fb343cd6dcbb4234564f6R33) [[2]](diffhunk://#diff-a174d4a41882d600e50a7aada5b20b472eac19f1e37fb343cd6dcbb4234564f6R94) [[3]](diffhunk://#diff-a174d4a41882d600e50a7aada5b20b472eac19f1e37fb343cd6dcbb4234564f6L115-R118) [[4]](diffhunk://#diff-88c32ef43bc3637256efcc782302b1b02ad3e7695f7fa3a28bd7a8d727a7a40dR11-R22)

**Documentation:**
- Updated the main documentation to describe the new Avalonia RDP view and its integration steps. (`README.md`)