### PR TITLE
Fix Avalonia OLE host activation, teardown, and keyboard routing (PR #179 follow-up)

### DIFF
--- a/dll/AxHost/RdpOleHost.cpp
+++ b/dll/AxHost/RdpOleHost.cpp
@@ -219,31 +219,20 @@ public:
         if (!m_pOleInPlaceActiveObject || !m_pOleObject)
             return OLE_E_NOT_INPLACEACTIVE;
 
-        // Track the UI-active state so repeated focus events do not issue
-        // redundant UIACTIVATE verbs or UIDeactivate calls.
-        if (active)
-        {
-            if (m_uiActive)
-                return S_OK;
-
-            HRESULT hr = m_pOleObject->DoVerb(
-                OLEIVERB_UIACTIVATE, NULL, m_pOleClientSite, 0, m_hWnd, &m_bounds);
-            if (FAILED(hr))
-                return hr;
-            m_uiActive = true;
-        }
-        else
-        {
-            if (!m_uiActive)
-                return S_OK;
-            m_uiActive = false;
-        }
+        // Do not issue OLEIVERB_UIACTIVATE here. This host presents the
+        // control through the off-screen output mirror and feeds it synthetic
+        // input (allowBackgroundInput=1); a real UIACTIVATE makes mstscax call
+        // SetFocus on its own window and change the active window, hijacking
+        // keyboard focus from the Avalonia surface and breaking later input
+        // and teardown. Frame/doc activation notifications give the control
+        // the activation state it needs (FocusReleased, focus tracking)
+        // without the focus grab.
+        if (m_uiActive == (active != FALSE))
+            return S_OK;
+        m_uiActive = active != FALSE;
 
         HRESULT frameHr = m_pOleInPlaceActiveObject->OnFrameWindowActivate(active);
         HRESULT docHr = m_pOleInPlaceActiveObject->OnDocWindowActivate(active);
-
-        if (!active && m_pOleInPlaceObject)
-            m_pOleInPlaceObject->UIDeactivate();
 
         return FAILED(frameHr) ? frameHr : docHr;
     }

--- a/dll/AxHost/RdpOleHost.cpp
+++ b/dll/AxHost/RdpOleHost.cpp
@@ -11,7 +11,7 @@ class CRdpOleHost : public IUnknown
 public:
     CRdpOleHost()
         : m_refCount(1), m_hWnd(NULL), m_contained(false), m_clientSiteSet(false),
-          m_miscStatus(0),
+          m_uiActive(false), m_miscStatus(0),
           m_pOleClientSite(NULL), m_pOleInPlaceSiteEx(NULL), m_pOleObject(NULL),
           m_pOleInPlaceObject(NULL), m_pOleInPlaceActiveObject(NULL)
     {
@@ -219,12 +219,24 @@ public:
         if (!m_pOleInPlaceActiveObject || !m_pOleObject)
             return OLE_E_NOT_INPLACEACTIVE;
 
+        // Track the UI-active state so repeated focus events do not issue
+        // redundant UIACTIVATE verbs or UIDeactivate calls.
         if (active)
         {
+            if (m_uiActive)
+                return S_OK;
+
             HRESULT hr = m_pOleObject->DoVerb(
                 OLEIVERB_UIACTIVATE, NULL, m_pOleClientSite, 0, m_hWnd, &m_bounds);
             if (FAILED(hr))
                 return hr;
+            m_uiActive = true;
+        }
+        else
+        {
+            if (!m_uiActive)
+                return S_OK;
+            m_uiActive = false;
         }
 
         HRESULT frameHr = m_pOleInPlaceActiveObject->OnFrameWindowActivate(active);
@@ -234,6 +246,24 @@ public:
             m_pOleInPlaceObject->UIDeactivate();
 
         return FAILED(frameHr) ? frameHr : docHr;
+    }
+
+    HRESULT SetFrameActive(BOOL active)
+    {
+        // Forwards top-level window activation only. Unlike SetActive this
+        // never changes the UI-active state: Avalonia retains logical focus
+        // when its window deactivates, so the control must stay UI-active.
+        return m_pOleInPlaceActiveObject
+            ? m_pOleInPlaceActiveObject->OnFrameWindowActivate(active)
+            : OLE_E_NOT_INPLACEACTIVE;
+    }
+
+    HRESULT SetFrameWindow(HWND hWndFrame)
+    {
+        if (!m_pOleInPlaceSiteEx)
+            return OLE_E_NOT_INPLACEACTIVE;
+
+        return m_pOleInPlaceSiteEx->SetFrameWindow(hWndFrame);
     }
 
     HRESULT TranslateAccelerator(LPMSG pMsg)
@@ -280,6 +310,7 @@ public:
         SafeRelease(m_pOleClientSite);
 
         m_hWnd = NULL;
+        m_uiActive = false;
         m_miscStatus = 0;
         SetRectEmpty(&m_bounds);
     }
@@ -292,6 +323,7 @@ private:
     RECT m_bounds;
     bool m_contained;
     bool m_clientSiteSet;
+    bool m_uiActive;
     DWORD m_miscStatus;
     CRdpOleClientSite* m_pOleClientSite;
     CRdpOleInPlaceSiteEx* m_pOleInPlaceSiteEx;
@@ -347,6 +379,26 @@ HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetActive(
         return E_POINTER;
 
     return reinterpret_cast<CRdpOleHost*>(pHost)->SetActive(active);
+}
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetFrameActive(
+    MsRdpEx_RdpOleHost* pHost,
+    BOOL active)
+{
+    if (!pHost)
+        return E_POINTER;
+
+    return reinterpret_cast<CRdpOleHost*>(pHost)->SetFrameActive(active);
+}
+
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetFrameWindow(
+    MsRdpEx_RdpOleHost* pHost,
+    HWND hWndFrame)
+{
+    if (!pHost)
+        return E_POINTER;
+
+    return reinterpret_cast<CRdpOleHost*>(pHost)->SetFrameWindow(hWndFrame);
 }
 
 HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_TranslateAccelerator(

--- a/dll/AxHost/RdpOleSite.cpp
+++ b/dll/AxHost/RdpOleSite.cpp
@@ -3,6 +3,7 @@
 
 #include <new>
 
+
 CRdpOleClientSite::CRdpOleClientSite(IUnknown* pUnkOuter)
 {
     m_refCount = 1;
@@ -464,6 +465,139 @@ STDMETHODIMP CRdpOleClientSite::OnRequestEdit(DISPID dispID)
     return S_OK;
 }
 
+// Tear-off wrappers for the in-place site. CRdpOleInPlaceSiteEx implements
+// both IOleInPlaceSiteEx and IOleInPlaceFrame, which share IOleWindow; these
+// wrappers give the site and frame roles distinct GetWindow behavior. The
+// wrappers own the site reference, so outer-host teardown releases the site
+// only after the control has released every tear-off it cached.
+class CRdpInPlaceSiteWindow : public IOleInPlaceSiteEx
+{
+public:
+    CRdpInPlaceSiteWindow(CRdpOleInPlaceSiteEx* pSite) : m_refCount(1), m_pSite(pSite)
+    {
+        m_pSite->AddRef();
+    }
+
+    STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
+    {
+        if (riid == IID_IUnknown || riid == IID_IOleWindow ||
+            riid == IID_IOleInPlaceSite || riid == IID_IOleInPlaceSiteEx)
+        {
+            *ppv = static_cast<IOleInPlaceSiteEx*>(this);
+            AddRef();
+            return S_OK;
+        }
+        return m_pSite->QueryInterface(riid, ppv);
+    }
+
+    STDMETHOD_(ULONG, AddRef)() override
+    {
+        return InterlockedIncrement(&m_refCount);
+    }
+
+    STDMETHOD_(ULONG, Release)() override
+    {
+        ULONG refCount = InterlockedDecrement(&m_refCount);
+        if (refCount == 0)
+            delete this;
+        return refCount;
+    }
+
+    STDMETHOD(GetWindow)(HWND* phwnd) override { return m_pSite->GetSiteWindow(phwnd); }
+    STDMETHOD(ContextSensitiveHelp)(BOOL f) override { return m_pSite->ContextSensitiveHelp(f); }
+    STDMETHOD(CanInPlaceActivate)() override { return m_pSite->CanInPlaceActivate(); }
+    STDMETHOD(OnInPlaceActivate)() override { return m_pSite->OnInPlaceActivate(); }
+    STDMETHOD(OnUIActivate)() override { return m_pSite->OnUIActivate(); }
+    STDMETHOD(GetWindowContext)(IOleInPlaceFrame** ppFrame, IOleInPlaceUIWindow** ppDoc,
+        LPRECT lprcPosRect, LPRECT lprcClipRect, LPOLEINPLACEFRAMEINFO lpFrameInfo) override
+    {
+        return m_pSite->GetWindowContext(ppFrame, ppDoc, lprcPosRect, lprcClipRect, lpFrameInfo);
+    }
+    STDMETHOD(Scroll)(SIZE s) override { return m_pSite->Scroll(s); }
+    STDMETHOD(OnUIDeactivate)(BOOL f) override { return m_pSite->OnUIDeactivate(f); }
+    STDMETHOD(OnInPlaceDeactivate)() override { return m_pSite->OnInPlaceDeactivate(); }
+    STDMETHOD(DiscardUndoState)() override { return m_pSite->DiscardUndoState(); }
+    STDMETHOD(DeactivateAndUndo)() override { return m_pSite->DeactivateAndUndo(); }
+    STDMETHOD(OnPosRectChange)(LPCRECT r) override { return m_pSite->OnPosRectChange(r); }
+    STDMETHOD(OnInPlaceActivateEx)(BOOL* pfNoRedraw, DWORD dwFlags) override
+    {
+        return m_pSite->OnInPlaceActivateEx(pfNoRedraw, dwFlags);
+    }
+    STDMETHOD(OnInPlaceDeactivateEx)(BOOL fNoRedraw) override
+    {
+        return m_pSite->OnInPlaceDeactivateEx(fNoRedraw);
+    }
+    STDMETHOD(RequestUIActivate)() override { return m_pSite->RequestUIActivate(); }
+
+private:
+    ~CRdpInPlaceSiteWindow() { SafeRelease(m_pSite); }
+
+    LONG m_refCount;
+    CRdpOleInPlaceSiteEx* m_pSite;
+};
+
+class CRdpInPlaceFrameWindow : public IOleInPlaceFrame
+{
+public:
+    CRdpInPlaceFrameWindow(CRdpOleInPlaceSiteEx* pSite) : m_refCount(1), m_pSite(pSite)
+    {
+        m_pSite->AddRef();
+    }
+
+    STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
+    {
+        if (riid == IID_IUnknown || riid == IID_IOleWindow ||
+            riid == IID_IOleInPlaceUIWindow || riid == IID_IOleInPlaceFrame)
+        {
+            *ppv = static_cast<IOleInPlaceFrame*>(this);
+            AddRef();
+            return S_OK;
+        }
+        return m_pSite->QueryInterface(riid, ppv);
+    }
+
+    STDMETHOD_(ULONG, AddRef)() override
+    {
+        return InterlockedIncrement(&m_refCount);
+    }
+
+    STDMETHOD_(ULONG, Release)() override
+    {
+        ULONG refCount = InterlockedDecrement(&m_refCount);
+        if (refCount == 0)
+            delete this;
+        return refCount;
+    }
+
+    STDMETHOD(GetWindow)(HWND* phwnd) override { return m_pSite->GetFrameWindow(phwnd); }
+    STDMETHOD(ContextSensitiveHelp)(BOOL f) override { return m_pSite->ContextSensitiveHelp(f); }
+    STDMETHOD(GetBorder)(LPRECT r) override { return m_pSite->GetBorder(r); }
+    STDMETHOD(RequestBorderSpace)(LPCBORDERWIDTHS b) override { return m_pSite->RequestBorderSpace(b); }
+    STDMETHOD(SetBorderSpace)(LPCBORDERWIDTHS b) override { return m_pSite->SetBorderSpace(b); }
+    STDMETHOD(SetActiveObject)(IOleInPlaceActiveObject* p, LPCOLESTR s) override
+    {
+        return m_pSite->SetActiveObject(p, s);
+    }
+    STDMETHOD(InsertMenus)(HMENU h, LPOLEMENUGROUPWIDTHS m) override
+    {
+        return m_pSite->InsertMenus(h, m);
+    }
+    STDMETHOD(SetMenu)(HMENU h, HOLEMENU o, HWND w) override { return m_pSite->SetMenu(h, o, w); }
+    STDMETHOD(RemoveMenus)(HMENU h) override { return m_pSite->RemoveMenus(h); }
+    STDMETHOD(SetStatusText)(LPCOLESTR s) override { return m_pSite->SetStatusText(s); }
+    STDMETHOD(EnableModeless)(BOOL f) override { return m_pSite->EnableModeless(f); }
+    STDMETHOD(TranslateAccelerator)(LPMSG m, WORD w) override
+    {
+        return m_pSite->TranslateAccelerator(m, w);
+    }
+
+private:
+    ~CRdpInPlaceFrameWindow() { SafeRelease(m_pSite); }
+
+    LONG m_refCount;
+    CRdpOleInPlaceSiteEx* m_pSite;
+};
+
 CRdpOleInPlaceSiteEx::CRdpOleInPlaceSiteEx(IUnknown* pUnkOuter)
     : m_refCount(1), m_hWnd(0), m_hWndFrame(0), m_pOleInPlaceObject(NULL)
 {
@@ -488,11 +622,22 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::QueryInterface(REFIID riid, void** ppv)
     if (riid == IID_IUnknown && m_pUnkOuter) {
         return m_pUnkOuter->QueryInterface(riid, ppv);
     }
-    else if (riid == IID_IOleWindow || riid == IID_IOleInPlaceSite || riid == IID_IOleInPlaceSiteEx) {
+    else if (riid == IID_IOleWindow) {
+        // Ambiguous: IOleWindow is shared by the site and frame tear-offs.
+        // Resolve it to the in-place site, matching the historical behavior.
         *ppv = static_cast<IOleInPlaceSiteEx*>(this);
     }
+    else if (riid == IID_IOleInPlaceSite || riid == IID_IOleInPlaceSiteEx) {
+        *ppv = new (std::nothrow) CRdpInPlaceSiteWindow(this);
+        if (!*ppv)
+            return E_OUTOFMEMORY;
+        return S_OK;
+    }
     else if (riid == IID_IOleInPlaceUIWindow || riid == IID_IOleInPlaceFrame) {
-        *ppv = static_cast<IOleInPlaceFrame*>(this);
+        *ppv = new (std::nothrow) CRdpInPlaceFrameWindow(this);
+        if (!*ppv)
+            return E_OUTOFMEMORY;
+        return S_OK;
     }
     else if (m_pUnkOuter) {
         return m_pUnkOuter->QueryInterface(riid, ppv);
@@ -522,14 +667,31 @@ STDMETHODIMP_(ULONG) CRdpOleInPlaceSiteEx::Release()
     return refCount;
 }
 
-// IOleWindow methods
+// IOleWindow methods. The virtual override is never called through the
+// site's own vtable: QueryInterface hands out the tear-off wrappers below so
+// that IOleInPlaceSite::GetWindow reports the off-screen host window while
+// IOleInPlaceFrame::GetWindow reports the real top-level frame window.
 STDMETHODIMP CRdpOleInPlaceSiteEx::GetWindow(HWND* phwnd)
+{
+    return GetSiteWindow(phwnd);
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::GetSiteWindow(HWND* phwnd)
 {
     if (!phwnd)
         return E_POINTER;
 
     *phwnd = m_hWnd;
     return m_hWnd ? S_OK : E_FAIL;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::GetFrameWindow(HWND* phwnd)
+{
+    if (!phwnd)
+        return E_POINTER;
+
+    *phwnd = m_hWndFrame ? m_hWndFrame : m_hWnd;
+    return *phwnd ? S_OK : E_FAIL;
 }
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::ContextSensitiveHelp(BOOL fEnterMode)
@@ -741,3 +903,4 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::TranslateAccelerator(LPMSG lpmsg, WORD wID)
     UNREFERENCED_PARAMETER(wID);
     return lpmsg ? S_FALSE : E_POINTER;
 }
+

--- a/dll/AxHost/RdpOleSite.cpp
+++ b/dll/AxHost/RdpOleSite.cpp
@@ -465,138 +465,6 @@ STDMETHODIMP CRdpOleClientSite::OnRequestEdit(DISPID dispID)
     return S_OK;
 }
 
-// Tear-off wrappers for the in-place site. CRdpOleInPlaceSiteEx implements
-// both IOleInPlaceSiteEx and IOleInPlaceFrame, which share IOleWindow; these
-// wrappers give the site and frame roles distinct GetWindow behavior. The
-// wrappers own the site reference, so outer-host teardown releases the site
-// only after the control has released every tear-off it cached.
-class CRdpInPlaceSiteWindow : public IOleInPlaceSiteEx
-{
-public:
-    CRdpInPlaceSiteWindow(CRdpOleInPlaceSiteEx* pSite) : m_refCount(1), m_pSite(pSite)
-    {
-        m_pSite->AddRef();
-    }
-
-    STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
-    {
-        if (riid == IID_IUnknown || riid == IID_IOleWindow ||
-            riid == IID_IOleInPlaceSite || riid == IID_IOleInPlaceSiteEx)
-        {
-            *ppv = static_cast<IOleInPlaceSiteEx*>(this);
-            AddRef();
-            return S_OK;
-        }
-        return m_pSite->QueryInterface(riid, ppv);
-    }
-
-    STDMETHOD_(ULONG, AddRef)() override
-    {
-        return InterlockedIncrement(&m_refCount);
-    }
-
-    STDMETHOD_(ULONG, Release)() override
-    {
-        ULONG refCount = InterlockedDecrement(&m_refCount);
-        if (refCount == 0)
-            delete this;
-        return refCount;
-    }
-
-    STDMETHOD(GetWindow)(HWND* phwnd) override { return m_pSite->GetSiteWindow(phwnd); }
-    STDMETHOD(ContextSensitiveHelp)(BOOL f) override { return m_pSite->ContextSensitiveHelp(f); }
-    STDMETHOD(CanInPlaceActivate)() override { return m_pSite->CanInPlaceActivate(); }
-    STDMETHOD(OnInPlaceActivate)() override { return m_pSite->OnInPlaceActivate(); }
-    STDMETHOD(OnUIActivate)() override { return m_pSite->OnUIActivate(); }
-    STDMETHOD(GetWindowContext)(IOleInPlaceFrame** ppFrame, IOleInPlaceUIWindow** ppDoc,
-        LPRECT lprcPosRect, LPRECT lprcClipRect, LPOLEINPLACEFRAMEINFO lpFrameInfo) override
-    {
-        return m_pSite->GetWindowContext(ppFrame, ppDoc, lprcPosRect, lprcClipRect, lpFrameInfo);
-    }
-    STDMETHOD(Scroll)(SIZE s) override { return m_pSite->Scroll(s); }
-    STDMETHOD(OnUIDeactivate)(BOOL f) override { return m_pSite->OnUIDeactivate(f); }
-    STDMETHOD(OnInPlaceDeactivate)() override { return m_pSite->OnInPlaceDeactivate(); }
-    STDMETHOD(DiscardUndoState)() override { return m_pSite->DiscardUndoState(); }
-    STDMETHOD(DeactivateAndUndo)() override { return m_pSite->DeactivateAndUndo(); }
-    STDMETHOD(OnPosRectChange)(LPCRECT r) override { return m_pSite->OnPosRectChange(r); }
-    STDMETHOD(OnInPlaceActivateEx)(BOOL* pfNoRedraw, DWORD dwFlags) override
-    {
-        return m_pSite->OnInPlaceActivateEx(pfNoRedraw, dwFlags);
-    }
-    STDMETHOD(OnInPlaceDeactivateEx)(BOOL fNoRedraw) override
-    {
-        return m_pSite->OnInPlaceDeactivateEx(fNoRedraw);
-    }
-    STDMETHOD(RequestUIActivate)() override { return m_pSite->RequestUIActivate(); }
-
-private:
-    ~CRdpInPlaceSiteWindow() { SafeRelease(m_pSite); }
-
-    LONG m_refCount;
-    CRdpOleInPlaceSiteEx* m_pSite;
-};
-
-class CRdpInPlaceFrameWindow : public IOleInPlaceFrame
-{
-public:
-    CRdpInPlaceFrameWindow(CRdpOleInPlaceSiteEx* pSite) : m_refCount(1), m_pSite(pSite)
-    {
-        m_pSite->AddRef();
-    }
-
-    STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
-    {
-        if (riid == IID_IUnknown || riid == IID_IOleWindow ||
-            riid == IID_IOleInPlaceUIWindow || riid == IID_IOleInPlaceFrame)
-        {
-            *ppv = static_cast<IOleInPlaceFrame*>(this);
-            AddRef();
-            return S_OK;
-        }
-        return m_pSite->QueryInterface(riid, ppv);
-    }
-
-    STDMETHOD_(ULONG, AddRef)() override
-    {
-        return InterlockedIncrement(&m_refCount);
-    }
-
-    STDMETHOD_(ULONG, Release)() override
-    {
-        ULONG refCount = InterlockedDecrement(&m_refCount);
-        if (refCount == 0)
-            delete this;
-        return refCount;
-    }
-
-    STDMETHOD(GetWindow)(HWND* phwnd) override { return m_pSite->GetFrameWindow(phwnd); }
-    STDMETHOD(ContextSensitiveHelp)(BOOL f) override { return m_pSite->ContextSensitiveHelp(f); }
-    STDMETHOD(GetBorder)(LPRECT r) override { return m_pSite->GetBorder(r); }
-    STDMETHOD(RequestBorderSpace)(LPCBORDERWIDTHS b) override { return m_pSite->RequestBorderSpace(b); }
-    STDMETHOD(SetBorderSpace)(LPCBORDERWIDTHS b) override { return m_pSite->SetBorderSpace(b); }
-    STDMETHOD(SetActiveObject)(IOleInPlaceActiveObject* p, LPCOLESTR s) override
-    {
-        return m_pSite->SetActiveObject(p, s);
-    }
-    STDMETHOD(InsertMenus)(HMENU h, LPOLEMENUGROUPWIDTHS m) override
-    {
-        return m_pSite->InsertMenus(h, m);
-    }
-    STDMETHOD(SetMenu)(HMENU h, HOLEMENU o, HWND w) override { return m_pSite->SetMenu(h, o, w); }
-    STDMETHOD(RemoveMenus)(HMENU h) override { return m_pSite->RemoveMenus(h); }
-    STDMETHOD(SetStatusText)(LPCOLESTR s) override { return m_pSite->SetStatusText(s); }
-    STDMETHOD(EnableModeless)(BOOL f) override { return m_pSite->EnableModeless(f); }
-    STDMETHOD(TranslateAccelerator)(LPMSG m, WORD w) override
-    {
-        return m_pSite->TranslateAccelerator(m, w);
-    }
-
-private:
-    ~CRdpInPlaceFrameWindow() { SafeRelease(m_pSite); }
-
-    LONG m_refCount;
-    CRdpOleInPlaceSiteEx* m_pSite;
-};
 
 CRdpOleInPlaceSiteEx::CRdpOleInPlaceSiteEx(IUnknown* pUnkOuter)
     : m_refCount(1), m_hWnd(0), m_hWndFrame(0), m_pOleInPlaceObject(NULL)
@@ -622,22 +490,11 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::QueryInterface(REFIID riid, void** ppv)
     if (riid == IID_IUnknown && m_pUnkOuter) {
         return m_pUnkOuter->QueryInterface(riid, ppv);
     }
-    else if (riid == IID_IOleWindow) {
-        // Ambiguous: IOleWindow is shared by the site and frame tear-offs.
-        // Resolve it to the in-place site, matching the historical behavior.
+    else if (riid == IID_IOleWindow || riid == IID_IOleInPlaceSite || riid == IID_IOleInPlaceSiteEx) {
         *ppv = static_cast<IOleInPlaceSiteEx*>(this);
     }
-    else if (riid == IID_IOleInPlaceSite || riid == IID_IOleInPlaceSiteEx) {
-        *ppv = new (std::nothrow) CRdpInPlaceSiteWindow(this);
-        if (!*ppv)
-            return E_OUTOFMEMORY;
-        return S_OK;
-    }
     else if (riid == IID_IOleInPlaceUIWindow || riid == IID_IOleInPlaceFrame) {
-        *ppv = new (std::nothrow) CRdpInPlaceFrameWindow(this);
-        if (!*ppv)
-            return E_OUTOFMEMORY;
-        return S_OK;
+        *ppv = static_cast<IOleInPlaceFrame*>(this);
     }
     else if (m_pUnkOuter) {
         return m_pUnkOuter->QueryInterface(riid, ppv);
@@ -667,31 +524,18 @@ STDMETHODIMP_(ULONG) CRdpOleInPlaceSiteEx::Release()
     return refCount;
 }
 
-// IOleWindow methods. The virtual override is never called through the
-// site's own vtable: QueryInterface hands out the tear-off wrappers below so
-// that IOleInPlaceSite::GetWindow reports the off-screen host window while
-// IOleInPlaceFrame::GetWindow reports the real top-level frame window.
+// IOleWindow methods. Both the site and frame roles report the off-screen
+// host window here: the real top-level window is exposed only through
+// OLEINPLACEFRAMEINFO::hwndFrame so control-owned dialogs parent correctly.
+// Returning the real window from GetWindow lets mstscax capture/hook it
+// during UI activation, which hijacks input from the Avalonia surface.
 STDMETHODIMP CRdpOleInPlaceSiteEx::GetWindow(HWND* phwnd)
-{
-    return GetSiteWindow(phwnd);
-}
-
-STDMETHODIMP CRdpOleInPlaceSiteEx::GetSiteWindow(HWND* phwnd)
 {
     if (!phwnd)
         return E_POINTER;
 
     *phwnd = m_hWnd;
     return m_hWnd ? S_OK : E_FAIL;
-}
-
-STDMETHODIMP CRdpOleInPlaceSiteEx::GetFrameWindow(HWND* phwnd)
-{
-    if (!phwnd)
-        return E_POINTER;
-
-    *phwnd = m_hWndFrame ? m_hWndFrame : m_hWnd;
-    return *phwnd ? S_OK : E_FAIL;
 }
 
 STDMETHODIMP CRdpOleInPlaceSiteEx::ContextSensitiveHelp(BOOL fEnterMode)

--- a/dll/AxHost/RdpOleSite.cpp
+++ b/dll/AxHost/RdpOleSite.cpp
@@ -1,6 +1,8 @@
 
 #include "RdpOleSite.h"
 
+#include <new>
+
 CRdpOleClientSite::CRdpOleClientSite(IUnknown* pUnkOuter)
 {
     m_refCount = 1;
@@ -132,13 +134,87 @@ STDMETHODIMP CRdpOleClientSite::ParseDisplayName(
     return E_NOTIMPL;
 }
 
+// AxHost answers EnumObjects with an empty enumerator. A control that
+// enumerates sibling embeddings gets a clean "no objects" answer instead of
+// E_NOTIMPL.
+class CRdpEmptyEnumUnknown : public IEnumUnknown
+{
+public:
+    CRdpEmptyEnumUnknown() : m_refCount(1) { }
+
+    STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
+    {
+        if (!ppv)
+            return E_POINTER;
+
+        if (riid == IID_IUnknown || riid == IID_IEnumUnknown)
+        {
+            *ppv = static_cast<IEnumUnknown*>(this);
+            AddRef();
+            return S_OK;
+        }
+
+        *ppv = NULL;
+        return E_NOINTERFACE;
+    }
+
+    STDMETHOD_(ULONG, AddRef)() override
+    {
+        return InterlockedIncrement(&m_refCount);
+    }
+
+    STDMETHOD_(ULONG, Release)() override
+    {
+        ULONG refCount = InterlockedDecrement(&m_refCount);
+        if (refCount == 0)
+            delete this;
+        return refCount;
+    }
+
+    STDMETHOD(Next)(ULONG celt, IUnknown** rgelt, ULONG* pceltFetched) override
+    {
+        if (!rgelt || (celt > 1 && !pceltFetched))
+            return E_POINTER;
+
+        for (ULONG i = 0; i < celt; i++)
+            rgelt[i] = NULL;
+        if (pceltFetched)
+            *pceltFetched = 0;
+        return S_FALSE;
+    }
+
+    STDMETHOD(Skip)(ULONG celt) override
+    {
+        UNREFERENCED_PARAMETER(celt);
+        return S_FALSE;
+    }
+
+    STDMETHOD(Reset)() override
+    {
+        return S_OK;
+    }
+
+    STDMETHOD(Clone)(IEnumUnknown** ppenum) override
+    {
+        if (!ppenum)
+            return E_POINTER;
+
+        *ppenum = new (std::nothrow) CRdpEmptyEnumUnknown();
+        return *ppenum ? S_OK : E_OUTOFMEMORY;
+    }
+
+private:
+    LONG m_refCount;
+};
+
 STDMETHODIMP CRdpOleClientSite::EnumObjects(DWORD grfFlags, IEnumUnknown** ppenum)
 {
     UNREFERENCED_PARAMETER(grfFlags);
     if (!ppenum)
         return E_POINTER;
-    *ppenum = NULL;
-    return E_NOTIMPL;
+
+    *ppenum = new (std::nothrow) CRdpEmptyEnumUnknown();
+    return *ppenum ? S_OK : E_OUTOFMEMORY;
 }
 
 STDMETHODIMP CRdpOleClientSite::LockContainer(BOOL fLock)
@@ -389,7 +465,7 @@ STDMETHODIMP CRdpOleClientSite::OnRequestEdit(DISPID dispID)
 }
 
 CRdpOleInPlaceSiteEx::CRdpOleInPlaceSiteEx(IUnknown* pUnkOuter)
-    : m_refCount(1), m_hWnd(0), m_pOleInPlaceObject(NULL)
+    : m_refCount(1), m_hWnd(0), m_hWndFrame(0), m_pOleInPlaceObject(NULL)
 {
     m_pUnkOuter = pUnkOuter;
     m_pUnkOuter->AddRef();
@@ -494,7 +570,11 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::GetWindowContext(IOleInPlaceFrame** ppFrame, 
     {
         lpFrameInfo->cb = sizeof(OLEINPLACEFRAMEINFO);
         lpFrameInfo->fMDIApp = FALSE;
-        lpFrameInfo->hwndFrame = m_hWnd;
+        // Report the real top-level window as the OLE frame so that
+        // control-owned dialogs (certificate warnings, credential prompts)
+        // are parented to a visible window instead of the hidden off-screen
+        // surface. The control itself stays parented to m_hWnd.
+        lpFrameInfo->hwndFrame = m_hWndFrame ? m_hWndFrame : m_hWnd;
         lpFrameInfo->haccel = NULL;
         lpFrameInfo->cAccelEntries = 0;
     }
@@ -574,6 +654,12 @@ STDMETHODIMP CRdpOleInPlaceSiteEx::RequestUIActivate()
 STDMETHODIMP CRdpOleInPlaceSiteEx::SetWindow(HWND hWnd)
 {
     m_hWnd = hWnd;
+    return S_OK;
+}
+
+STDMETHODIMP CRdpOleInPlaceSiteEx::SetFrameWindow(HWND hWndFrame)
+{
+    m_hWndFrame = hWndFrame;
     return S_OK;
 }
 

--- a/dll/AxHost/RdpOleSite.h
+++ b/dll/AxHost/RdpOleSite.h
@@ -80,8 +80,11 @@ public:
     STDMETHOD_(ULONG, AddRef)() override;
     STDMETHOD_(ULONG, Release)() override;
 
-    // IOleWindow methods
+    // IOleWindow methods. The site tear-off reports the off-screen host
+    // window, while the frame tear-off reports the real top-level window.
     STDMETHOD(GetWindow)(HWND* phwnd) override;
+    STDMETHOD(GetSiteWindow)(HWND* phwnd);
+    STDMETHOD(GetFrameWindow)(HWND* phwnd);
     STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // IOleInPlaceSite methods

--- a/dll/AxHost/RdpOleSite.h
+++ b/dll/AxHost/RdpOleSite.h
@@ -80,11 +80,8 @@ public:
     STDMETHOD_(ULONG, AddRef)() override;
     STDMETHOD_(ULONG, Release)() override;
 
-    // IOleWindow methods. The site tear-off reports the off-screen host
-    // window, while the frame tear-off reports the real top-level window.
+    // IOleWindow methods
     STDMETHOD(GetWindow)(HWND* phwnd) override;
-    STDMETHOD(GetSiteWindow)(HWND* phwnd);
-    STDMETHOD(GetFrameWindow)(HWND* phwnd);
     STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // IOleInPlaceSite methods

--- a/dll/AxHost/RdpOleSite.h
+++ b/dll/AxHost/RdpOleSite.h
@@ -120,11 +120,13 @@ public:
 
     // Additional methods specific to your implementation
     STDMETHOD(SetWindow)(HWND hWnd);
+    STDMETHOD(SetFrameWindow)(HWND hWndFrame);
     STDMETHOD(SetInPlaceObject)(IOleInPlaceObject* pOleInPlaceObject);
 
 private:
     ULONG m_refCount;
     HWND m_hWnd;
+    HWND m_hWndFrame; // real top-level window for OLE frame identity; falls back to m_hWnd
     IOleInPlaceObject* m_pOleInPlaceObject; // weak; owned by the outer host
     IUnknown* m_pUnkOuter;
 };

--- a/dll/MsRdpEx.def
+++ b/dll/MsRdpEx.def
@@ -29,8 +29,12 @@ EXPORTS
     MsRdpEx_RdpOleHost_Attach
     MsRdpEx_RdpOleHost_SetBounds
     MsRdpEx_RdpOleHost_SetActive
+    MsRdpEx_RdpOleHost_SetFrameActive
+    MsRdpEx_RdpOleHost_SetFrameWindow
     MsRdpEx_RdpOleHost_TranslateAccelerator
     MsRdpEx_RdpOleHost_Release
+    MsRdpEx_Instance_SetOutputMirrorEnabled
+    MsRdpEx_Instance_GetInputWindow
     MsRdpEx_OutputMirror_GetFrameVersion
     MsRdpEx_OutputMirrorCapture_Create
     MsRdpEx_OutputMirrorCapture_GetFrameVersion

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -521,6 +521,44 @@ void MsRdpEx_RdpInstance_Free(CMsRdpExInstance* instance)
     instance->Release();
 }
 
+HRESULT STDAPICALLTYPE MsRdpEx_Instance_SetOutputMirrorEnabled(
+    IUnknown* pInstance,
+    bool outputMirrorEnabled)
+{
+    if (!pInstance)
+        return E_INVALIDARG;
+
+    IMsRdpExInstance* instance = NULL;
+    HRESULT hr = pInstance->QueryInterface(
+        IID_IMsRdpExInstance, (void**)&instance);
+    if (FAILED(hr))
+        return hr;
+
+    hr = instance->SetOutputMirrorEnabled(outputMirrorEnabled);
+    instance->Release();
+    return hr;
+}
+
+HRESULT STDAPICALLTYPE MsRdpEx_Instance_GetInputWindow(
+    IUnknown* pInstance,
+    HWND* phInputCaptureWnd)
+{
+    if (!pInstance || !phInputCaptureWnd)
+        return E_INVALIDARG;
+
+    *phInputCaptureWnd = NULL;
+
+    IMsRdpExInstance* instance = NULL;
+    HRESULT hr = pInstance->QueryInterface(
+        IID_IMsRdpExInstance, (void**)&instance);
+    if (FAILED(hr))
+        return hr;
+
+    hr = instance->GetInputWindow(phInputCaptureWnd);
+    instance->Release();
+    return hr;
+}
+
 typedef struct _MsRdpEx_InstanceManager MsRdpEx_InstanceManager;
 
 struct _MsRdpEx_InstanceManager

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/Devolutions.MsRdpEx.Avalonia.csproj
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/Devolutions.MsRdpEx.Avalonia.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MsRdpEx_Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Interop.MSTSCLib.Generated\Interop.MSTSCLib.Generated.csproj" />
   </ItemGroup>
 </Project>

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/MsRdpExInstanceHandle.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/MsRdpExInstanceHandle.cs
@@ -10,6 +10,7 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
 {
     private static readonly Guid InterfaceId = new("94CDA65A-EFDF-4453-B8B2-2493A12D31C7");
     private readonly object syncRoot = new();
+    private readonly InstanceApi? instanceApi;
     private readonly OutputMirrorCaptureApi? captureApi;
     private readonly OutputMirrorGetFrameVersion? getFrameVersion;
     private nint capture;
@@ -17,9 +18,11 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
 
     public MsRdpExInstanceHandle(
         nint rdpControl,
+        InstanceApi? instanceApi,
         OutputMirrorCaptureApi? captureApi,
         OutputMirrorGetFrameVersion? getFrameVersion)
     {
+        this.instanceApi = instanceApi;
         this.captureApi = captureApi;
         this.getFrameVersion = getFrameVersion;
         Guid interfaceId = InterfaceId;
@@ -49,6 +52,16 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
         lock (syncRoot)
         {
             ObjectDisposedException.ThrowIf(instance == 0, this);
+
+            if (instanceApi is not null)
+            {
+                Marshal.ThrowExceptionForHR(
+                    instanceApi.SetOutputMirrorEnabled(instance, enabled ? (byte)1 : (byte)0));
+                return;
+            }
+
+            // Legacy fallback for MsRdpEx builds without the instance exports:
+            // vtable slot 8 (3 IUnknown + 5 methods) of IMsRdpExInstance.
             nint* vtable = *(nint**)instance;
             var setEnabled = (delegate* unmanaged[Stdcall]<nint, byte, int>)vtable[8];
             int hr = setEnabled(instance, enabled ? (byte)1 : (byte)0);
@@ -61,6 +74,14 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
         lock (syncRoot)
         {
             ObjectDisposedException.ThrowIf(instance == 0, this);
+
+            if (instanceApi is not null)
+            {
+                Marshal.ThrowExceptionForHR(instanceApi.GetInputWindow(instance, out nint inputWindow));
+                return inputWindow;
+            }
+
+            // Legacy fallback: vtable slot 16 of IMsRdpExInstance.
             nint* vtable = *(nint**)instance;
             var getInputWindow = (delegate* unmanaged[Stdcall]<nint, nint*, int>)vtable[16];
             nint window;
@@ -87,6 +108,8 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
             if (getFrameVersion is null)
                 return false;
 
+            // Legacy fallback: vtable slot 5 (GetOutputMirrorObject) of
+            // IMsRdpExInstance. Newer MsRdpEx builds take the capture path above.
             nint* vtable = *(nint**)instance;
             var getOutputMirror = (delegate* unmanaged[Stdcall]<nint, nint*, int>)vtable[5];
             nint outputMirror;
@@ -110,6 +133,8 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
             if (capture != 0 && captureApi is not null)
                 return WithNativeCapture(action, captureApi);
 
+            // Legacy STA fallback for MsRdpEx builds without the capture API:
+            // vtable slots 23-25 (GetShadowBitmap/Lock/UnlockShadowBitmap).
             nint* vtable = *(nint**)instance;
             var getShadowBitmap = (delegate* unmanaged[Stdcall]<nint, nint*, nint*, nint*, uint*, uint*, uint*, byte>)vtable[23];
             var lockShadowBitmap = (delegate* unmanaged[Stdcall]<nint, void>)vtable[24];
@@ -209,6 +234,16 @@ internal sealed unsafe class MsRdpExInstanceHandle : IDisposable
             api.Unlock(capture);
         }
     }
+
+    internal sealed record InstanceApi(
+        InstanceSetOutputMirrorEnabled SetOutputMirrorEnabled,
+        InstanceGetInputWindow GetInputWindow);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    internal delegate int InstanceSetOutputMirrorEnabled(nint instance, byte enabled);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    internal delegate int InstanceGetInputWindow(nint instance, out nint inputWindow);
 
     internal sealed record OutputMirrorCaptureApi(
         OutputMirrorCaptureCreate Create,

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
@@ -40,3 +40,46 @@ Then place the view in Avalonia XAML:
 
 Avalonia remains an application dependency so the base MsRdpEx package does
 not impose Avalonia on its WinForms and .NET Framework consumers.
+
+## Focus, activation, and keyboard routing
+
+The view drives OLE UI activation from Avalonia focus (UI-activate on
+`GotFocus`, UI-deactivate on `LostFocus`) and forwards top-level window
+`Activated`/`Deactivated` to the OLE frame. Window deactivation also releases
+any forwarded keys and mouse buttons so they never stay pressed remotely.
+While the view is focused, a low-level keyboard hook forwards keys to the
+remote session; keys pass through untouched when the window is inactive or no
+connection is live, so Tab and focus traversal keep working.
+
+Set `LocalKeyFilter` to let the hosting application claim keys (menu
+accelerators, global shortcuts) before they are forwarded remotely:
+
+```csharp
+RdpView.LocalKeyFilter = (virtualKey, keyUp, systemKey) =>
+    virtualKey == 0x77; // keep F8 local, both press and release
+```
+
+A claimed key passes through to normal local processing and is never sent to
+the remote session. Answer consistently for a key press and its release.
+`UseRemoteKeyboardShortcuts` still controls whether Windows/system
+combinations (Alt+Tab, Alt+F4, Windows key) stay local.
+
+## Dispose contract
+
+Detaching the view from the visual tree intentionally keeps the session alive
+for docking and tab reparenting. Owners **must** call `Dispose()` on final
+close, on the Avalonia UI thread (`VerifyAccess` throws otherwise): final
+teardown of the OLE host, the keyboard hook, and COM wrappers happens there.
+OLE is uninitialized only when this library performed the initialization
+itself and no other `RdpClientView` session remains; OLE initialized by the
+hosting application is never torn down.
+
+## Known limitations
+
+- **File drop replaces the local clipboard content.** Dropping local files
+  onto the view stages them as `CF_HDROP` on the Windows clipboard and sends
+  a synthetic Ctrl+V to the remote session; any previous clipboard content is
+  discarded.
+- **No remote-to-local pointer drag-out.** Dragging a file out of the remote
+  session onto the local desktop is not supported: the OLE drag source lives
+  on the off-screen control window and cannot reach the local desktop.

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
@@ -71,8 +71,9 @@ for docking and tab reparenting. Owners **must** call `Dispose()` on final
 close, on the Avalonia UI thread (`VerifyAccess` throws otherwise): final
 teardown of the OLE host, the keyboard hook, and COM wrappers happens there.
 OLE is uninitialized only when this library performed the initialization
-itself and no other `RdpClientView` session remains; OLE initialized by the
-hosting application is never torn down.
+itself and no other `RdpClientView` session remains; a balancing uninitialize
+deferred because OLE was already initialized by the hosting application is
+carried forward to the last surviving session instead.
 
 ## Known limitations
 

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
@@ -43,17 +43,18 @@ not impose Avalonia on its WinForms and .NET Framework consumers.
 
 ## Focus, activation, and keyboard routing
 
-The view drives OLE frame/document activation from Avalonia focus and
-forwards top-level window `Activated`/`Deactivated` to the OLE frame. The
-control is deliberately *not* UI-activated with `OLEIVERB_UIACTIVATE`: this
-hosting model feeds the off-screen control synthetic input
-(`allowBackgroundInput=1`), and a real UI-activate makes mstscax grab
-keyboard focus and change the active window, hijacking input from the
-Avalonia surface. Window deactivation releases any forwarded keys and mouse
-buttons so they never stay pressed remotely. While the view is focused, a
-low-level keyboard hook forwards keys to the remote session; keys pass
-through untouched when the window is inactive or no connection is live, so
-Tab and focus traversal keep working.
+The view forwards top-level window `Activated`/`Deactivated` to the OLE
+frame, but deliberately does not drive OLE UI/document activation from
+Avalonia focus. This hosting model feeds the off-screen control synthetic
+input (`allowBackgroundInput=1`); activating mstscax's hidden window lets it
+take native mouse capture and keyboard focus away from the Avalonia surface.
+After each synthetic button-down the view also releases any capture taken by
+the hidden input HWND before Avalonia acquires pointer capture. Window
+deactivation removes the keyboard hook and releases any forwarded keys and
+mouse buttons so they never stay pressed remotely. While the view is focused,
+a low-level keyboard hook forwards keys only when the containing native window
+is also the foreground window; keys pass through untouched when another local
+application is active or no connection is live.
 
 Set `LocalKeyFilter` to let the hosting application claim keys (menu
 accelerators, global shortcuts) before they are forwarded remotely:

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/README.md
@@ -43,13 +43,17 @@ not impose Avalonia on its WinForms and .NET Framework consumers.
 
 ## Focus, activation, and keyboard routing
 
-The view drives OLE UI activation from Avalonia focus (UI-activate on
-`GotFocus`, UI-deactivate on `LostFocus`) and forwards top-level window
-`Activated`/`Deactivated` to the OLE frame. Window deactivation also releases
-any forwarded keys and mouse buttons so they never stay pressed remotely.
-While the view is focused, a low-level keyboard hook forwards keys to the
-remote session; keys pass through untouched when the window is inactive or no
-connection is live, so Tab and focus traversal keep working.
+The view drives OLE frame/document activation from Avalonia focus and
+forwards top-level window `Activated`/`Deactivated` to the OLE frame. The
+control is deliberately *not* UI-activated with `OLEIVERB_UIACTIVATE`: this
+hosting model feeds the off-screen control synthetic input
+(`allowBackgroundInput=1`), and a real UI-activate makes mstscax grab
+keyboard focus and change the active window, hijacking input from the
+Avalonia surface. Window deactivation releases any forwarded keys and mouse
+buttons so they never stay pressed remotely. While the view is focused, a
+low-level keyboard hook forwards keys to the remote session; keys pass
+through untouched when the window is inactive or no connection is live, so
+Tab and focus traversal keep working.
 
 Set `LocalKeyFilter` to let the hosting application claim keys (menu
 accelerators, global shortcuts) before they are forwarded remotely:

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -503,6 +503,17 @@ internal sealed class RdpActiveXSession : IDisposable
 
         nuint wParam = (nuint)((uint)buttons | ((uint)xButton << 16));
         SendMessageW(inputWindow, message, wParam, MakeLParam(x, y));
+
+        // mstscax can call SetCapture for its hidden input HWND on button-down.
+        // The visible Avalonia surface must own the physical pointer stream;
+        // otherwise the hidden HWND receives the real button-up and keeps all
+        // subsequent local clicks captive. The subclass above suppresses the
+        // resulting WM_CAPTURECHANGED so the remote drag remains active, and
+        // RdpClientView acquires Avalonia pointer capture immediately after
+        // this method returns.
+        if (buttonDown && GetCapture() == inputWindow)
+            ReleaseCapture();
+
         SynchronizeCursor(inputWindow);
     }
 
@@ -1210,6 +1221,13 @@ internal sealed class RdpActiveXSession : IDisposable
 
     [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
     private static extern nint SendMessageW(nint window, uint message, nuint wParam, nint lParam);
+
+    [DllImport("user32.dll", ExactSpelling = true)]
+    private static extern nint GetCapture();
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ReleaseCapture();
 
     [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -60,10 +60,16 @@ internal sealed class RdpActiveXSession : IDisposable
     private static nint msRdpExModule;
     private static string? loadedLibraryPath;
     private static readonly object NativeActivationLock = new();
+    private static readonly object OleInitLock = new();
+    private static int oleSessionCount;
     private static RdpOleHostAttach? rdpOleHostAttach;
     private static RdpOleHostSetBounds? rdpOleHostSetBounds;
+    private static RdpOleHostSetActive? rdpOleHostSetActive;
+    private static RdpOleHostSetFrameActive? rdpOleHostSetFrameActive;
+    private static RdpOleHostSetFrameWindow? rdpOleHostSetFrameWindow;
     private static RdpOleHostTranslateAccelerator? rdpOleHostTranslateAccelerator;
     private static RdpOleHostRelease? rdpOleHostRelease;
+    private static MsRdpExInstanceHandle.InstanceApi? instanceApi;
     private static MsRdpExInstanceHandle.OutputMirrorCaptureApi? outputMirrorCaptureApi;
     private static MsRdpExInstanceHandle.OutputMirrorGetFrameVersion? outputMirrorGetFrameVersion;
     private static readonly UIntPtr InputWindowSubclassId = new(1);
@@ -75,7 +81,9 @@ internal sealed class RdpActiveXSession : IDisposable
     private nint hostWindow;
     private nint oleHost;
     private nint inputWindowSubclassHandle;
-    private bool oleInitialized;
+    private bool oleScopeEntered;
+    private bool oleInitializedByUs;
+    private bool oleUiActive;
     private bool disposed;
     private bool remoteMouseDragActive;
     private int sessionDesktopWidth;
@@ -114,9 +122,15 @@ internal sealed class RdpActiveXSession : IDisposable
 
         try
         {
+            // Only an S_OK result means this call initialized OLE; S_FALSE means
+            // another component on this thread already owns it (for example
+            // Avalonia's OleContext, which never uninitializes). Ownership is
+            // tracked so Dispose never tears down OLE it did not initialize.
             int oleResult = OleInitialize(0);
             Marshal.ThrowExceptionForHR(oleResult);
-            oleInitialized = true;
+            oleInitializedByUs = oleResult == 0; // S_OK
+            EnterOleScope();
+            oleScopeEntered = true;
 
             int surfaceWidth = ClampDesktopDimension(width);
             int surfaceHeight = ClampDesktopDimension(height);
@@ -151,11 +165,13 @@ internal sealed class RdpActiveXSession : IDisposable
                         "All views in one process must use the same native library.");
                 }
 
-                Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", axName.Trim());
-                msRdpExModule = msRdpExModule == 0 ? NativeLibrary.Load(normalizedPath) : msRdpExModule;
-                loadedLibraryPath ??= normalizedPath;
-                EnsureOleHostExports(msRdpExModule);
-                control = CreateComInstance(msRdpExModule, classId);
+                control = WithAxNameEnvironment(axName.Trim(), () =>
+                {
+                    msRdpExModule = msRdpExModule == 0 ? NativeLibrary.Load(normalizedPath) : msRdpExModule;
+                    loadedLibraryPath ??= normalizedPath;
+                    EnsureOleHostExports(msRdpExModule);
+                    return CreateComInstance(msRdpExModule, classId);
+                });
             }
 
             unsafe
@@ -178,6 +194,7 @@ internal sealed class RdpActiveXSession : IDisposable
 
                     instance = new MsRdpExInstanceHandle(
                         control,
+                        instanceApi,
                         outputMirrorCaptureApi,
                         outputMirrorGetFrameVersion);
                 }
@@ -285,6 +302,53 @@ internal sealed class RdpActiveXSession : IDisposable
             PublishStatus("Disconnecting...");
             client.Disconnect();
         }
+    }
+
+    /// <summary>
+    /// Drives OLE UI activation (OLEIVERB_UIACTIVATE / UIDeactivate plus
+    /// OnDocWindowActivate) from view focus changes. Redundant transitions are
+    /// suppressed both here and in the native host.
+    /// </summary>
+    public void SetUiActive(bool active)
+    {
+        if (disposed || oleHost == 0 || rdpOleHostSetActive is null || oleUiActive == active)
+            return;
+
+        oleUiActive = active;
+        int hr = rdpOleHostSetActive(oleHost, active ? 1 : 0);
+        if (hr < 0)
+            PublishStatus($"RDP OLE activation failed: 0x{hr:X8}");
+    }
+
+    /// <summary>
+    /// Forwards top-level window activation to the OLE frame
+    /// (OnFrameWindowActivate) without touching the UI-active state: Avalonia
+    /// retains logical focus while its window is deactivated.
+    /// </summary>
+    public void SetFrameActive(bool active)
+    {
+        if (disposed || oleHost == 0 || rdpOleHostSetFrameActive is null)
+            return;
+
+        int hr = rdpOleHostSetFrameActive(oleHost, active ? 1 : 0);
+        if (hr < 0)
+            PublishStatus($"RDP OLE frame activation failed: 0x{hr:X8}");
+    }
+
+    /// <summary>
+    /// Reports the real top-level window as the OLE frame window so that
+    /// control-owned dialogs (certificate warnings, credential prompts) are
+    /// parented to a visible window. Pass 0 to fall back to the off-screen
+    /// host window.
+    /// </summary>
+    public void SetFrameWindow(nint frameWindow)
+    {
+        if (disposed || oleHost == 0 || rdpOleHostSetFrameWindow is null)
+            return;
+
+        int hr = rdpOleHostSetFrameWindow(oleHost, frameWindow);
+        if (hr < 0)
+            PublishStatus($"RDP OLE frame window update failed: 0x{hr:X8}");
     }
 
     public bool ResizeDisplay(int width, int height, double renderScaling)
@@ -575,10 +639,28 @@ internal sealed class RdpActiveXSession : IDisposable
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_Attach"));
         rdpOleHostSetBounds ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostSetBounds>(
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_SetBounds"));
+        rdpOleHostSetActive ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostSetActive>(
+            NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_SetActive"));
         rdpOleHostTranslateAccelerator ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostTranslateAccelerator>(
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_TranslateAccelerator"));
         rdpOleHostRelease ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostRelease>(
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_Release"));
+
+        if (rdpOleHostSetFrameActive is null &&
+            NativeLibrary.TryGetExport(library, "MsRdpEx_RdpOleHost_SetFrameActive", out nint setFrameActive))
+        {
+            rdpOleHostSetFrameActive =
+                Marshal.GetDelegateForFunctionPointer<RdpOleHostSetFrameActive>(setFrameActive);
+        }
+
+        if (rdpOleHostSetFrameWindow is null &&
+            NativeLibrary.TryGetExport(library, "MsRdpEx_RdpOleHost_SetFrameWindow", out nint setFrameWindow))
+        {
+            rdpOleHostSetFrameWindow =
+                Marshal.GetDelegateForFunctionPointer<RdpOleHostSetFrameWindow>(setFrameWindow);
+        }
+
+        instanceApi ??= TryLoadInstanceApi(library);
 
         if (outputMirrorGetFrameVersion is null &&
             NativeLibrary.TryGetExport(library, "MsRdpEx_OutputMirror_GetFrameVersion", out nint export))
@@ -588,6 +670,63 @@ internal sealed class RdpActiveXSession : IDisposable
         }
 
         outputMirrorCaptureApi ??= TryLoadOutputMirrorCaptureApi(library);
+    }
+
+    // MSRDPEX_AXNAME is a process-global read by MsRdpEx's DllGetClassObject.
+    // Scope it to the activation call and restore the previous value so that
+    // other in-process RDP activators never observe a stale name. Callers must
+    // hold NativeActivationLock; components activating RDP controls outside
+    // this lock must set and restore the variable themselves.
+    internal static T WithAxNameEnvironment<T>(string axName, Func<T> action)
+    {
+        string? previousAxName = Environment.GetEnvironmentVariable("MSRDPEX_AXNAME");
+        Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", axName);
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", previousAxName);
+        }
+    }
+
+    internal static void EnterOleScope()
+    {
+        lock (OleInitLock)
+        {
+            oleSessionCount++;
+        }
+    }
+
+    // Returns true when the caller must balance its own S_OK OleInitialize:
+    // only when it performed the initialization itself and no other session
+    // remains. When the owning session is disposed before later sessions, OLE
+    // intentionally stays initialized for the process lifetime rather than
+    // risking tearing down OLE underneath the hosting application (Avalonia's
+    // OleContext never balances its own OleInitialize). Sessions are assumed
+    // to live on the same (UI) thread, matching OleInitialize's per-thread
+    // semantics.
+    internal static bool ExitOleScope(bool initializedByUs)
+    {
+        lock (OleInitLock)
+        {
+            oleSessionCount--;
+            return initializedByUs && oleSessionCount == 0;
+        }
+    }
+
+    private static MsRdpExInstanceHandle.InstanceApi? TryLoadInstanceApi(nint library)
+    {
+        if (!NativeLibrary.TryGetExport(library, "MsRdpEx_Instance_SetOutputMirrorEnabled", out nint setEnabled) ||
+            !NativeLibrary.TryGetExport(library, "MsRdpEx_Instance_GetInputWindow", out nint getInputWindow))
+        {
+            return null;
+        }
+
+        return new MsRdpExInstanceHandle.InstanceApi(
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.InstanceSetOutputMirrorEnabled>(setEnabled),
+            Marshal.GetDelegateForFunctionPointer<MsRdpExInstanceHandle.InstanceGetInputWindow>(getInputWindow));
     }
 
     private static MsRdpExInstanceHandle.OutputMirrorCaptureApi? TryLoadOutputMirrorCaptureApi(nint library)
@@ -805,6 +944,8 @@ internal sealed class RdpActiveXSession : IDisposable
         instance?.Dispose();
         instance = null;
 
+        // The OLE host closes, deactivates, and de-sites the control on this
+        // (UI) thread before any managed wrapper is released.
         if (oleHost != 0)
         {
             nint host = oleHost;
@@ -812,9 +953,21 @@ internal sealed class RdpActiveXSession : IDisposable
             rdpOleHostRelease?.Invoke(host);
         }
 
+        oleUiActive = false;
+
+        // Release the managed COM wrapper deterministically where the runtime
+        // supports it. The generated interop wraps the control through
+        // ComInterfaceMarshaller (StrategyBasedComWrappers), which offers no
+        // deterministic release; because the OLE host above has already closed
+        // and de-sited the control, that wrapper's final GC release is inert.
+        // A built-in RCW (legacy interop path) is released explicitly here.
+        object? rawClient = client is not null ? ProxyObject.Unpack(client) : null;
         client = null;
         IsConnectionActive = false;
         IsLoginCompleted = false;
+
+        if (rawClient is not null && Marshal.IsComObject(rawClient))
+            Marshal.FinalReleaseComObject(rawClient);
 
         if (hostWindow != 0)
         {
@@ -822,10 +975,13 @@ internal sealed class RdpActiveXSession : IDisposable
             hostWindow = 0;
         }
 
-        if (oleInitialized)
+        if (oleScopeEntered)
         {
-            OleUninitialize();
-            oleInitialized = false;
+            oleScopeEntered = false;
+            bool initializedByUs = oleInitializedByUs;
+            oleInitializedByUs = false;
+            if (ExitOleScope(initializedByUs))
+                OleUninitialize();
         }
     }
 
@@ -951,6 +1107,15 @@ internal sealed class RdpActiveXSession : IDisposable
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int RdpOleHostSetBounds(nint host, ref NativeRect bounds);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int RdpOleHostSetActive(nint host, int active);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int RdpOleHostSetFrameActive(nint host, int active);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int RdpOleHostSetFrameWindow(nint host, nint frameWindow);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int RdpOleHostTranslateAccelerator(nint host, ref NativeMessage message);

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -309,9 +309,12 @@ internal sealed class RdpActiveXSession : IDisposable
     }
 
     /// <summary>
-    /// Drives OLE UI activation (OLEIVERB_UIACTIVATE / UIDeactivate plus
-    /// OnDocWindowActivate) from view focus changes. Redundant transitions are
-    /// suppressed both here and in the native host.
+    /// Pushes focus-driven OLE activation state (OnFrameWindowActivate /
+    /// OnDocWindowActivate) from view focus changes. The control is not
+    /// UI-activated with OLEIVERB_UIACTIVATE: in this hosting model that makes
+    /// mstscax grab keyboard focus and change the active window, hijacking
+    /// input from the Avalonia surface. Redundant transitions are suppressed
+    /// both here and in the native host.
     /// </summary>
     public void SetUiActive(bool active)
     {

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -83,6 +83,7 @@ internal sealed class RdpActiveXSession : IDisposable
     private nint inputWindowSubclassHandle;
     private bool oleScopeEntered;
     private bool oleInitializedByUs;
+    private bool oleUninitializePending;
     private bool oleUiActive;
     private bool disposed;
     private bool remoteMouseDragActive;
@@ -100,6 +101,7 @@ internal sealed class RdpActiveXSession : IDisposable
     public event EventHandler<RdpRemoteDesktopSizeChangedEventArgs>? RemoteDesktopSizeChanged;
     public event EventHandler<RdpFocusReleasedEventArgs>? FocusReleased;
     public event EventHandler<RdpStatusChangedEventArgs>? StatusChanged;
+    public event EventHandler? Disconnected;
 
     public RdpActiveXSession()
     {
@@ -122,10 +124,12 @@ internal sealed class RdpActiveXSession : IDisposable
 
         try
         {
-            // Only an S_OK result means this call initialized OLE; S_FALSE means
-            // another component on this thread already owns it (for example
-            // Avalonia's OleContext, which never uninitializes). Ownership is
-            // tracked so Dispose never tears down OLE it did not initialize.
+            // Every successful OleInitialize (S_OK or S_FALSE) increments the
+            // thread's OLE initialization count and must be balanced once.
+            // OleUninitialize is deferred when other sessions remain and, when
+            // this call got S_FALSE, deferred to a later S_OK-initialized
+            // session so OLE initialized by the hosting application (Avalonia's
+            // OleContext never uninitializes) is not torn down underneath it.
             int oleResult = OleInitialize(0);
             Marshal.ThrowExceptionForHR(oleResult);
             oleInitializedByUs = oleResult == 0; // S_OK
@@ -314,10 +318,16 @@ internal sealed class RdpActiveXSession : IDisposable
         if (disposed || oleHost == 0 || rdpOleHostSetActive is null || oleUiActive == active)
             return;
 
-        oleUiActive = active;
+        // Commit the managed state only after the native transition succeeds
+        // so a failed UIACTIVATE can be retried on the next focus change.
         int hr = rdpOleHostSetActive(oleHost, active ? 1 : 0);
         if (hr < 0)
+        {
             PublishStatus($"RDP OLE activation failed: 0x{hr:X8}");
+            return;
+        }
+
+        oleUiActive = active;
     }
 
     /// <summary>
@@ -699,21 +709,40 @@ internal sealed class RdpActiveXSession : IDisposable
         }
     }
 
-    // Returns true when the caller must balance its own S_OK OleInitialize:
-    // only when it performed the initialization itself and no other session
-    // remains. When the owning session is disposed before later sessions, OLE
-    // intentionally stays initialized for the process lifetime rather than
-    // risking tearing down OLE underneath the hosting application (Avalonia's
-    // OleContext never balances its own OleInitialize). Sessions are assumed
-    // to live on the same (UI) thread, matching OleInitialize's per-thread
-    // semantics.
+    // Test-only: resets the process-wide session count so the OLE scope rules
+    // can be exercised deterministically in randomized test order.
+    internal static void ResetOleScopeForTesting()
+    {
+        lock (OleInitLock)
+        {
+            oleSessionCount = 0;
+        }
+    }
+
+    // Returns true when the caller must balance its OleInitialize now: when
+    // it is the last remaining session and either it performed the S_OK
+    // initialization itself or it is inheriting a balance deferred by an
+    // earlier session that got S_FALSE (which must not run while Avalonia may
+    // still own OLE). Sessions are assumed to live on the same (UI) thread,
+    // matching OleInitialize's per-thread semantics.
     internal static bool ExitOleScope(bool initializedByUs)
     {
         lock (OleInitLock)
         {
             oleSessionCount--;
-            return initializedByUs && oleSessionCount == 0;
+            return oleSessionCount == 0 && initializedByUs;
         }
+    }
+
+    // Hands this session's OleInitialize balance to an existing older session
+    // that got S_FALSE, so that session's dispose performs the balancing
+    // OleUninitialize instead of this one. Called when a new session that owns
+    // the OLE initialization is created while foreign-initialized sessions are
+    // still alive; without it the new session's dispose would tear down OLE
+    // underneath the surviving sessions.
+    internal void MarkOleUninitializePending()
+    {
+        oleUninitializePending = true;
     }
 
     private static MsRdpExInstanceHandle.InstanceApi? TryLoadInstanceApi(nint library)
@@ -908,6 +937,7 @@ internal sealed class RdpActiveXSession : IDisposable
         {
             IsConnectionActive = false;
             IsLoginCompleted = false;
+            Disconnected?.Invoke(this, EventArgs.Empty);
             string detail = string.IsNullOrWhiteSpace(args.DisconnectErrorMessage)
                 ? $"reason {args.DisconnectReason}"
                 : args.DisconnectErrorMessage;
@@ -978,10 +1008,21 @@ internal sealed class RdpActiveXSession : IDisposable
         if (oleScopeEntered)
         {
             oleScopeEntered = false;
-            bool initializedByUs = oleInitializedByUs;
-            oleInitializedByUs = false;
-            if (ExitOleScope(initializedByUs))
+            if (oleUninitializePending)
+            {
+                // This session inherited the OleInitialize balance deferred by
+                // an earlier session that got S_FALSE and is now the last one.
+                oleUninitializePending = false;
+                ExitOleScope(true);
                 OleUninitialize();
+            }
+            else
+            {
+                bool initializedByUs = oleInitializedByUs;
+                oleInitializedByUs = false;
+                if (ExitOleScope(initializedByUs))
+                    OleUninitialize();
+            }
         }
     }
 

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -381,7 +381,6 @@ public class RdpClientView : UserControl, IDisposable
         resizeTimer.Stop();
         ReleaseForwardedKeys();
         ReleaseMouseButtons();
-        session?.SetUiActive(false);
         // Deactivate the frame before dropping its window so the control is
         // not left believing a detached frame is still active.
         session?.SetFrameActive(false);
@@ -404,9 +403,6 @@ public class RdpClientView : UserControl, IDisposable
 
         if (topLevel is Window window)
             session.SetFrameActive(window.IsActive);
-
-        if (IsKeyboardFocusWithin)
-            session.SetUiActive(true);
     }
 
     /// <summary>
@@ -688,7 +684,6 @@ public class RdpClientView : UserControl, IDisposable
     private void OnControlLostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
         UninstallKeyboardHook();
-        session?.SetUiActive(false);
         ReleaseForwardedKeys();
         if (!ContinuePhysicalMouseDrag())
             ReleaseMouseButtons();
@@ -696,17 +691,23 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnControlGotFocus(object? sender, FocusChangedEventArgs e)
     {
-        session?.SetUiActive(true);
         InstallKeyboardHook();
     }
 
     private void OnWindowActivated(object? sender, EventArgs e)
     {
         session?.SetFrameActive(true);
+        if (IsKeyboardFocusWithin)
+            InstallKeyboardHook();
     }
 
     private void OnWindowDeactivated(object? sender, EventArgs e)
     {
+        // Remove the process-wide hook immediately. Avalonia's IsActive and
+        // logical-focus state can lag a native foreground-window transition;
+        // leaving the hook installed during that interval can swallow input
+        // intended for another local application.
+        UninstallKeyboardHook();
         session?.SetFrameActive(false);
 
         // Avalonia retains logical keyboard focus while its window is
@@ -739,9 +740,19 @@ public class RdpClientView : UserControl, IDisposable
     // must let keys pass through so Tab and focus traversal keep working in
     // the host application.
     internal static bool ShouldForwardKeys(
-        bool isViewOnly, bool focusWithin, bool windowActive, bool connectionActive)
+        bool isViewOnly,
+        bool focusWithin,
+        bool windowActive,
+        bool connectionActive,
+        bool foregroundWindowMatches)
     {
-        return !isViewOnly && focusWithin && windowActive && connectionActive;
+        return !isViewOnly && focusWithin && windowActive && connectionActive && foregroundWindowMatches;
+    }
+
+    private bool IsTopLevelForegroundWindow()
+    {
+        nint topLevelWindow = topLevel?.TryGetPlatformHandle()?.Handle ?? 0;
+        return topLevelWindow != 0 && GetForegroundWindow() == topLevelWindow;
     }
 
     private nint KeyboardHookProc(int code, nint wParam, nint lParam)
@@ -751,7 +762,8 @@ public class RdpClientView : UserControl, IDisposable
                 IsViewOnly,
                 IsKeyboardFocusWithin,
                 topLevel is not Window window || window.IsActive,
-                session?.IsConnectionActive == true))
+                session?.IsConnectionActive == true,
+                IsTopLevelForegroundWindow()))
         {
             return CallNextHookEx(keyboardHook, code, wParam, lParam);
         }
@@ -1599,6 +1611,9 @@ public class RdpClientView : UserControl, IDisposable
 
     [DllImport("user32.dll", ExactSpelling = true)]
     private static extern nint CallNextHookEx(nint hook, int code, nint wParam, nint lParam);
+
+    [DllImport("user32.dll", ExactSpelling = true)]
+    private static extern nint GetForegroundWindow();
 
     [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
     private static extern nint GlobalAlloc(uint flags, nuint bytes);

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -59,6 +59,7 @@ public class RdpClientView : UserControl, IDisposable
     private NativeMouseButtons pressedButtons;
     private readonly Dictionary<int, ForwardedKey> forwardedKeys = [];
     private readonly HashSet<int> localShortcutKeys = [];
+    private readonly HashSet<int> claimedLocalKeys = [];
     private int lastRemoteX;
     private int lastRemoteY;
     private bool dynamicResolutionEnabled;
@@ -66,6 +67,7 @@ public class RdpClientView : UserControl, IDisposable
     private double pendingRenderScaling = 1.0;
     private TopLevel? topLevel;
     private nint keyboardHook;
+    private bool sessionDisconnectedFired;
     private CancellationTokenSource? captureCancellation;
     private Task? captureTask;
     private int captureGeneration;
@@ -204,6 +206,14 @@ public class RdpClientView : UserControl, IDisposable
         activeSession.RemoteDesktopSizeChanged += OnSessionRemoteDesktopSizeChanged;
         activeSession.FocusReleased += OnSessionFocusReleased;
         activeSession.StatusChanged += OnSessionStatusChanged;
+        activeSession.Disconnected += OnSessionDisconnected;
+
+        // When this view is re-created after a previous view, the previous
+        // session may own the OLE initialization while the new session got
+        // S_FALSE (Avalonia already initialized OLE on this thread). Hand the
+        // balance to the older session so disposing the new one never tears
+        // down OLE underneath the survivor.
+        session?.MarkOleUninitializePending();
         session = activeSession;
 
         try
@@ -218,6 +228,7 @@ public class RdpClientView : UserControl, IDisposable
             activeSession.RemoteDesktopSizeChanged -= OnSessionRemoteDesktopSizeChanged;
             activeSession.FocusReleased -= OnSessionFocusReleased;
             activeSession.StatusChanged -= OnSessionStatusChanged;
+            activeSession.Disconnected -= OnSessionDisconnected;
             activeSession.Dispose();
             session = null;
             throw;
@@ -371,6 +382,9 @@ public class RdpClientView : UserControl, IDisposable
         ReleaseForwardedKeys();
         ReleaseMouseButtons();
         session?.SetUiActive(false);
+        // Deactivate the frame before dropping its window so the control is
+        // not left believing a detached frame is still active.
+        session?.SetFrameActive(false);
         session?.SetFrameWindow(0);
         topLevel = null;
 
@@ -428,6 +442,7 @@ public class RdpClientView : UserControl, IDisposable
             session.RemoteDesktopSizeChanged -= OnSessionRemoteDesktopSizeChanged;
             session.FocusReleased -= OnSessionFocusReleased;
             session.StatusChanged -= OnSessionStatusChanged;
+            session.Disconnected -= OnSessionDisconnected;
             session.Dispose();
             session = null;
         }
@@ -622,11 +637,16 @@ public class RdpClientView : UserControl, IDisposable
         if (IsViewOnly || !IsConnectionActive)
             return;
 
+        // When the low-level hook is installed it already consulted
+        // LocalKeyFilter for this event; only the fallback path evaluates it.
         if (TryGetVirtualKey(e.Key, out int virtualKey, out bool extended))
         {
             bool systemKey = IsSystemKey(e);
-            if (LocalKeyFilter is not null && LocalKeyFilter(virtualKey, false, systemKey))
+            if (keyboardHook == 0 && LocalKeyFilter is not null &&
+                LocalKeyFilter(virtualKey, false, systemKey))
+            {
                 return;
+            }
 
             session?.SendKey(virtualKey, false, extended, systemKey);
             forwardedKeys[virtualKey] = new ForwardedKey(0, extended, systemKey);
@@ -643,8 +663,11 @@ public class RdpClientView : UserControl, IDisposable
 
         if (TryGetVirtualKey(e.Key, out int virtualKey, out bool extended))
         {
-            if (LocalKeyFilter is not null && LocalKeyFilter(virtualKey, true, IsSystemKey(e)))
+            if (keyboardHook == 0 && LocalKeyFilter is not null &&
+                LocalKeyFilter(virtualKey, true, IsSystemKey(e)))
+            {
                 return;
+            }
 
             bool systemKey = forwardedKeys.TryGetValue(virtualKey, out ForwardedKey forwarded)
                 ? forwarded.SystemKey
@@ -748,9 +771,17 @@ public class RdpClientView : UserControl, IDisposable
             return CallNextHookEx(keyboardHook, code, wParam, lParam);
 
         // The hosting application can claim its own accelerators before the
-        // key is swallowed and forwarded to the remote session.
-        if (LocalKeyFilter is not null && LocalKeyFilter(virtualKey, keyUp, systemKey))
+        // key is swallowed and forwarded to the remote session. Claimed keys
+        // are tracked so a stateful filter does not run twice (the claim is
+        // decisive for the press and its release).
+        if (keyUp && claimedLocalKeys.Remove(virtualKey))
             return CallNextHookEx(keyboardHook, code, wParam, lParam);
+
+        if (keyDown && LocalKeyFilter is not null && LocalKeyFilter(virtualKey, keyUp, systemKey))
+        {
+            claimedLocalKeys.Add(virtualKey);
+            return CallNextHookEx(keyboardHook, code, wParam, lParam);
+        }
 
         // VK_PACKET carries the UTF-16 code unit in scanCode. This is the path
         // used by Windows Unicode input injection and by RDM's IME bridge.
@@ -1405,6 +1436,20 @@ public class RdpClientView : UserControl, IDisposable
     {
         ReleaseForwardedKeys();
         FocusReleased?.Invoke(this, e);
+    }
+
+    private void OnSessionDisconnected(object? sender, EventArgs e)
+    {
+        // The remote session is gone: drop the forwarded/claimed key state so
+        // a stale modifier does not distort shortcut routing after a reconnect
+        // and no orphaned release is sent to the next session.
+        if (sessionDisconnectedFired)
+            return;
+
+        sessionDisconnectedFired = true;
+        forwardedKeys.Clear();
+        claimedLocalKeys.Clear();
+        localShortcutKeys.Clear();
     }
 
     private void OnSessionStatusChanged(object? sender, RdpStatusChangedEventArgs e)

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -14,6 +14,18 @@ using static Devolutions.MsRdpEx.Avalonia.RdpActiveXSession;
 namespace Devolutions.MsRdpEx.Avalonia;
 
 /// <summary>
+/// Decides whether a key about to be forwarded to the remote session is
+/// claimed by the hosting application instead. Return true to keep the key
+/// local: it passes through to normal application processing (accelerators,
+/// menu shortcuts) and is not sent remotely. Implementations should answer
+/// consistently for a key press and its matching release.
+/// </summary>
+/// <param name="virtualKey">The Win32 virtual-key code.</param>
+/// <param name="keyUp">True for the key release, false for the key press.</param>
+/// <param name="systemKey">True when the key is a system (Alt) key message.</param>
+public delegate bool RdpLocalKeyFilter(int virtualKey, bool keyUp, bool systemKey);
+
+/// <summary>
 /// A pure Avalonia RDP surface. Pixels are copied from MsRdpEx's shadow DIB
 /// into a WriteableBitmap; no native HWND participates in the Avalonia visual
 /// tree.
@@ -135,6 +147,16 @@ public class RdpClientView : UserControl, IDisposable
     /// through the Windows CF_HDROP clipboard format.
     /// </summary>
     public bool AllowFileDrop { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets an optional filter that lets the hosting application claim
+    /// keys before they are forwarded to the remote session. While the view is
+    /// focused, the low-level keyboard hook forwards every key remotely; set
+    /// this filter to keep the host's own accelerators (for example menu
+    /// shortcuts) working. Claimed keys pass through to normal local
+    /// processing and are never sent to the remote session.
+    /// </summary>
+    public RdpLocalKeyFilter? LocalKeyFilter { get; set; }
 
     /// <summary>
     /// Gets or sets whether pointer and keyboard input is suppressed while the
@@ -316,9 +338,16 @@ public class RdpClientView : UserControl, IDisposable
         ObjectDisposedException.ThrowIf(disposed, this);
         topLevel = TopLevel.GetTopLevel(this);
 
+        if (topLevel is Window window)
+        {
+            window.Activated += OnWindowActivated;
+            window.Deactivated += OnWindowDeactivated;
+        }
+
         try
         {
             Initialize();
+            UpdateOleFrameState();
             StartCaptureWorker();
         }
         catch (Exception exception)
@@ -329,15 +358,41 @@ public class RdpClientView : UserControl, IDisposable
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
+        if (topLevel is Window window)
+        {
+            window.Activated -= OnWindowActivated;
+            window.Deactivated -= OnWindowDeactivated;
+        }
+
         StopCaptureWorker();
         UninstallKeyboardHook();
         mouseDragTimer.Stop();
         resizeTimer.Stop();
         ReleaseForwardedKeys();
         ReleaseMouseButtons();
+        session?.SetUiActive(false);
+        session?.SetFrameWindow(0);
         topLevel = null;
 
         base.OnDetachedFromVisualTree(e);
+    }
+
+    // Reports the real top-level window to the OLE host so control-owned
+    // dialogs (certificate warnings, credential prompts) are parented to a
+    // visible window, and pushes the current frame/focus activation state.
+    private void UpdateOleFrameState()
+    {
+        if (session is null)
+            return;
+
+        if (topLevel?.TryGetPlatformHandle() is { } platformHandle)
+            session.SetFrameWindow(platformHandle.Handle);
+
+        if (topLevel is Window window)
+            session.SetFrameActive(window.IsActive);
+
+        if (IsKeyboardFocusWithin)
+            session.SetUiActive(true);
     }
 
     /// <summary>
@@ -352,6 +407,13 @@ public class RdpClientView : UserControl, IDisposable
 
         VerifyAccess();
         disposed = true;
+
+        if (topLevel is Window window)
+        {
+            window.Activated -= OnWindowActivated;
+            window.Deactivated -= OnWindowDeactivated;
+        }
+
         StopCaptureWorker();
         UninstallKeyboardHook();
         mouseDragTimer.Stop();
@@ -557,12 +619,15 @@ public class RdpClientView : UserControl, IDisposable
     {
         base.OnKeyDown(e);
 
-        if (IsViewOnly)
+        if (IsViewOnly || !IsConnectionActive)
             return;
 
         if (TryGetVirtualKey(e.Key, out int virtualKey, out bool extended))
         {
             bool systemKey = IsSystemKey(e);
+            if (LocalKeyFilter is not null && LocalKeyFilter(virtualKey, false, systemKey))
+                return;
+
             session?.SendKey(virtualKey, false, extended, systemKey);
             forwardedKeys[virtualKey] = new ForwardedKey(0, extended, systemKey);
             e.Handled = true;
@@ -573,11 +638,14 @@ public class RdpClientView : UserControl, IDisposable
     {
         base.OnKeyUp(e);
 
-        if (IsViewOnly)
+        if (IsViewOnly || !IsConnectionActive)
             return;
 
         if (TryGetVirtualKey(e.Key, out int virtualKey, out bool extended))
         {
+            if (LocalKeyFilter is not null && LocalKeyFilter(virtualKey, true, IsSystemKey(e)))
+                return;
+
             bool systemKey = forwardedKeys.TryGetValue(virtualKey, out ForwardedKey forwarded)
                 ? forwarded.SystemKey
                 : IsSystemKey(e);
@@ -597,6 +665,7 @@ public class RdpClientView : UserControl, IDisposable
     private void OnControlLostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
         UninstallKeyboardHook();
+        session?.SetUiActive(false);
         ReleaseForwardedKeys();
         if (!ContinuePhysicalMouseDrag())
             ReleaseMouseButtons();
@@ -604,7 +673,24 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnControlGotFocus(object? sender, FocusChangedEventArgs e)
     {
+        session?.SetUiActive(true);
         InstallKeyboardHook();
+    }
+
+    private void OnWindowActivated(object? sender, EventArgs e)
+    {
+        session?.SetFrameActive(true);
+    }
+
+    private void OnWindowDeactivated(object? sender, EventArgs e)
+    {
+        session?.SetFrameActive(false);
+
+        // Avalonia retains logical keyboard focus while its window is
+        // deactivated, so LostFocus never fires. Release forwarded input here
+        // or keys and mouse buttons stay pressed in the remote session.
+        ReleaseForwardedKeys();
+        ReleaseMouseButtons();
     }
 
     private void InstallKeyboardHook()
@@ -625,10 +711,24 @@ public class RdpClientView : UserControl, IDisposable
             UnhookWindowsHookEx(hook);
     }
 
+    // Keys are trapped and forwarded only while the view is focused in an
+    // active window with a live connection. A focused but disconnected view
+    // must let keys pass through so Tab and focus traversal keep working in
+    // the host application.
+    internal static bool ShouldForwardKeys(
+        bool isViewOnly, bool focusWithin, bool windowActive, bool connectionActive)
+    {
+        return !isViewOnly && focusWithin && windowActive && connectionActive;
+    }
+
     private nint KeyboardHookProc(int code, nint wParam, nint lParam)
     {
-        if (code < 0 || keyboardHook == 0 || IsViewOnly || !IsKeyboardFocusWithin ||
-            topLevel is Window { IsActive: false })
+        if (code < 0 || keyboardHook == 0 ||
+            !ShouldForwardKeys(
+                IsViewOnly,
+                IsKeyboardFocusWithin,
+                topLevel is not Window window || window.IsActive,
+                session?.IsConnectionActive == true))
         {
             return CallNextHookEx(keyboardHook, code, wParam, lParam);
         }
@@ -641,7 +741,15 @@ public class RdpClientView : UserControl, IDisposable
 
         KeyboardHookData keyData = Marshal.PtrToStructure<KeyboardHookData>(lParam);
         int virtualKey = checked((int)keyData.VirtualKey);
+        bool extended = (keyData.Flags & LlkhfExtended) != 0;
+        bool systemKey = message is WmSystemKeyDown or WmSystemKeyUp;
+
         if (ShouldHandleShortcutLocally(virtualKey, keyDown, keyUp))
+            return CallNextHookEx(keyboardHook, code, wParam, lParam);
+
+        // The hosting application can claim its own accelerators before the
+        // key is swallowed and forwarded to the remote session.
+        if (LocalKeyFilter is not null && LocalKeyFilter(virtualKey, keyUp, systemKey))
             return CallNextHookEx(keyboardHook, code, wParam, lParam);
 
         // VK_PACKET carries the UTF-16 code unit in scanCode. This is the path
@@ -652,8 +760,6 @@ public class RdpClientView : UserControl, IDisposable
             return 1;
         }
 
-        bool extended = (keyData.Flags & LlkhfExtended) != 0;
-        bool systemKey = message is WmSystemKeyDown or WmSystemKeyUp;
         session?.SendKey(virtualKey, keyData.ScanCode, keyUp, extended, systemKey);
 
         if (keyDown)

--- a/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
+++ b/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
@@ -1,0 +1,106 @@
+using Devolutions.MsRdpEx.Avalonia;
+
+namespace MsRdpEx.Tests
+{
+    public class AvaloniaHostingTests
+    {
+        [Fact]
+        public void AxNameEnvironmentRestoresPreviousValue()
+        {
+            const string marker = "test-previous-axname";
+            Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", marker);
+
+            try
+            {
+                string observed = RdpActiveXSession.WithAxNameEnvironment(
+                    "mstsc",
+                    () => Environment.GetEnvironmentVariable("MSRDPEX_AXNAME")!);
+
+                Assert.Equal("mstsc", observed);
+                Assert.Equal(marker, Environment.GetEnvironmentVariable("MSRDPEX_AXNAME"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", null);
+            }
+        }
+
+        [Fact]
+        public void AxNameEnvironmentRestoresAfterException()
+        {
+            const string marker = "test-previous-axname";
+            Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", marker);
+
+            try
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    RdpActiveXSession.WithAxNameEnvironment<object>("mstsc", () =>
+                        throw new InvalidOperationException()));
+                Assert.Equal(marker, Environment.GetEnvironmentVariable("MSRDPEX_AXNAME"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", null);
+            }
+        }
+
+        [Fact]
+        public void AxNameEnvironmentClearsWhenPreviouslyUnset()
+        {
+            Environment.SetEnvironmentVariable("MSRDPEX_AXNAME", null);
+
+            RdpActiveXSession.WithAxNameEnvironment("mstsc", () => 0);
+
+            Assert.Null(Environment.GetEnvironmentVariable("MSRDPEX_AXNAME"));
+        }
+
+        [Theory]
+        // Keys are trapped and forwarded only while the view is focused in an
+        // active window with a live connection (focused-but-disconnected must
+        // pass keys through for local focus traversal).
+        [InlineData(false, true, true, true, true)]
+        [InlineData(true, true, true, true, false)]
+        [InlineData(false, false, true, true, false)]
+        [InlineData(false, true, false, true, false)]
+        [InlineData(false, true, true, false, false)]
+        public void ShouldForwardKeysTruthTable(
+            bool isViewOnly, bool focusWithin, bool windowActive, bool connectionActive, bool expected)
+        {
+            Assert.Equal(
+                expected,
+                RdpClientView.ShouldForwardKeys(isViewOnly, focusWithin, windowActive, connectionActive));
+        }
+
+        [Fact]
+        public void OleScopeUninitializesOnlyOwnedLastSession()
+        {
+            RdpActiveXSession.EnterOleScope(); // session A, owns its S_OK initialization
+            RdpActiveXSession.EnterOleScope(); // session B, got S_FALSE
+
+            Assert.False(RdpActiveXSession.ExitOleScope(false)); // B leaves first
+            Assert.True(RdpActiveXSession.ExitOleScope(true)); // A is last and owned OLE
+        }
+
+        [Fact]
+        public void OleScopeNeverUninitializesForeignOle()
+        {
+            RdpActiveXSession.EnterOleScope();
+
+            // S_FALSE path: OLE was initialized by another component (for
+            // example Avalonia's OleContext) and must never be torn down here.
+            Assert.False(RdpActiveXSession.ExitOleScope(false));
+        }
+
+        [Fact]
+        public void OleScopeKeepsOleWhenOwnerDisposedEarly()
+        {
+            RdpActiveXSession.EnterOleScope(); // owner
+            RdpActiveXSession.EnterOleScope(); // non-owner
+
+            // The owning session leaves while another session remains, so OLE
+            // intentionally stays initialized for the process lifetime.
+            Assert.False(RdpActiveXSession.ExitOleScope(true));
+            Assert.False(RdpActiveXSession.ExitOleScope(false));
+        }
+    }
+}

--- a/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
+++ b/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
@@ -58,17 +58,28 @@ namespace MsRdpEx.Tests
         // Keys are trapped and forwarded only while the view is focused in an
         // active window with a live connection (focused-but-disconnected must
         // pass keys through for local focus traversal).
-        [InlineData(false, true, true, true, true)]
-        [InlineData(true, true, true, true, false)]
-        [InlineData(false, false, true, true, false)]
-        [InlineData(false, true, false, true, false)]
-        [InlineData(false, true, true, false, false)]
+        [InlineData(false, true, true, true, true, true)]
+        [InlineData(true, true, true, true, true, false)]
+        [InlineData(false, false, true, true, true, false)]
+        [InlineData(false, true, false, true, true, false)]
+        [InlineData(false, true, true, false, true, false)]
+        [InlineData(false, true, true, true, false, false)]
         public void ShouldForwardKeysTruthTable(
-            bool isViewOnly, bool focusWithin, bool windowActive, bool connectionActive, bool expected)
+            bool isViewOnly,
+            bool focusWithin,
+            bool windowActive,
+            bool connectionActive,
+            bool foregroundWindowMatches,
+            bool expected)
         {
             Assert.Equal(
                 expected,
-                RdpClientView.ShouldForwardKeys(isViewOnly, focusWithin, windowActive, connectionActive));
+                RdpClientView.ShouldForwardKeys(
+                    isViewOnly,
+                    focusWithin,
+                    windowActive,
+                    connectionActive,
+                    foregroundWindowMatches));
         }
 
         // The OLE scope state is process-global, and xunit runs these tests in

--- a/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
+++ b/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
@@ -71,9 +71,14 @@ namespace MsRdpEx.Tests
                 RdpClientView.ShouldForwardKeys(isViewOnly, focusWithin, windowActive, connectionActive));
         }
 
+        // The OLE scope state is process-global, and xunit runs these tests in
+        // a random order, so each case resets the counter and asserts absolute
+        // rules: a non-owner never uninitializes, and an owner uninitializes
+        // only when it leaves last.
         [Fact]
         public void OleScopeUninitializesOnlyOwnedLastSession()
         {
+            RdpActiveXSession.ResetOleScopeForTesting();
             RdpActiveXSession.EnterOleScope(); // session A, owns its S_OK initialization
             RdpActiveXSession.EnterOleScope(); // session B, got S_FALSE
 
@@ -84,23 +89,44 @@ namespace MsRdpEx.Tests
         [Fact]
         public void OleScopeNeverUninitializesForeignOle()
         {
+            RdpActiveXSession.ResetOleScopeForTesting();
             RdpActiveXSession.EnterOleScope();
 
             // S_FALSE path: OLE was initialized by another component (for
-            // example Avalonia's OleContext) and must never be torn down here.
+            // example Avalonia's OleContext) and must never be torn down here,
+            // not even when the session leaves last.
             Assert.False(RdpActiveXSession.ExitOleScope(false));
         }
 
         [Fact]
         public void OleScopeKeepsOleWhenOwnerDisposedEarly()
         {
+            RdpActiveXSession.ResetOleScopeForTesting();
             RdpActiveXSession.EnterOleScope(); // owner
             RdpActiveXSession.EnterOleScope(); // non-owner
 
-            // The owning session leaves while another session remains, so OLE
-            // intentionally stays initialized for the process lifetime.
+            // The owning session leaves while another session remains, so the
+            // uninitialize is deferred to the last surviving session.
             Assert.False(RdpActiveXSession.ExitOleScope(true));
             Assert.False(RdpActiveXSession.ExitOleScope(false));
+        }
+
+        [Fact]
+        public void OleScopeDefersOwnerUninitializeWhileSessionsRemain()
+        {
+            // The deferral used when a session hands its balance to an older
+            // S_FALSE session: the owner leaving first must not uninitialize,
+            // and the last surviving session must.
+            RdpActiveXSession.ResetOleScopeForTesting();
+            RdpActiveXSession.EnterOleScope(); // A, got S_FALSE
+            RdpActiveXSession.EnterOleScope(); // B, got S_OK and hands its balance to A
+
+            Assert.False(RdpActiveXSession.ExitOleScope(true)); // B leaves first, no uninitialize
+            Assert.False(RdpActiveXSession.ExitOleScope(false)); // A defers its own S_FALSE balance
+
+            // A now runs the inherited balance as the last session.
+            RdpActiveXSession.EnterOleScope();
+            Assert.True(RdpActiveXSession.ExitOleScope(true));
         }
     }
 }

--- a/include/MsRdpEx/RdpInstance.h
+++ b/include/MsRdpEx/RdpInstance.h
@@ -88,6 +88,19 @@ void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Unlock(
 void STDAPICALLTYPE MsRdpEx_OutputMirrorCapture_Release(
     MsRdpEx_OutputMirrorCapture* pCapture);
 
+/*
+ * C-export wrappers around IMsRdpExInstance methods so that managed hosts do
+ * not need to depend on raw vtable offsets. Both are apartment-bound: call
+ * them on the COM thread that owns pInstance.
+ */
+HRESULT STDAPICALLTYPE MsRdpEx_Instance_SetOutputMirrorEnabled(
+    IUnknown* pInstance,
+    bool outputMirrorEnabled);
+
+HRESULT STDAPICALLTYPE MsRdpEx_Instance_GetInputWindow(
+    IUnknown* pInstance,
+    HWND* phInputCaptureWnd);
+
 bool MsRdpEx_InstanceManager_Add(CMsRdpExInstance* instance);
 bool MsRdpEx_InstanceManager_Remove(CMsRdpExInstance* instance);
 

--- a/include/MsRdpEx/RdpOleHost.h
+++ b/include/MsRdpEx/RdpOleHost.h
@@ -34,6 +34,26 @@ HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetActive(
     MsRdpEx_RdpOleHost* pHost,
     BOOL active);
 
+/*
+ * Forwards top-level window activation (OnFrameWindowActivate) without
+ * changing the control's UI-active state. Use this for window
+ * Activated/Deactivated notifications; use SetActive for focus changes.
+ */
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetFrameActive(
+    MsRdpEx_RdpOleHost* pHost,
+    BOOL active);
+
+/*
+ * Sets the real top-level window reported as the OLE frame window
+ * (OLEINPLACEFRAMEINFO::hwndFrame) so control-owned dialogs such as
+ * certificate and credential prompts are parented to a visible window.
+ * The control stays parented to the HWND passed to Attach. Pass NULL to
+ * fall back to the Attach HWND.
+ */
+HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetFrameWindow(
+    MsRdpEx_RdpOleHost* pHost,
+    HWND hWndFrame);
+
 HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_TranslateAccelerator(
     MsRdpEx_RdpOleHost* pHost,
     LPMSG pMsg);

--- a/include/MsRdpEx/RdpOleHost.h
+++ b/include/MsRdpEx/RdpOleHost.h
@@ -30,6 +30,14 @@ HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetBounds(
     MsRdpEx_RdpOleHost* pHost,
     LPCRECT pBounds);
 
+/*
+ * Pushes focus-driven activation state (OnFrameWindowActivate /
+ * OnDocWindowActivate) to the control. This deliberately does not issue
+ * OLEIVERB_UIACTIVATE: in the output-mirror hosting model the control is fed
+ * synthetic input (allowBackgroundInput=1), and a real UI-activate makes
+ * mstscax grab keyboard focus and change the active window, hijacking input
+ * from the host surface.
+ */
 HRESULT STDAPICALLTYPE MsRdpEx_RdpOleHost_SetActive(
     MsRdpEx_RdpOleHost* pHost,
     BOOL active);


### PR DESCRIPTION
Follow-up to #179 implementing the fixes from a deep OLE/ActiveX parity audit of the Avalonia `RdpClientView` host against the WinForms `AxHost` baseline.

## Changes by audit finding

**High severity**

- **F1 — OLE UI/frame activation was never driven.** `MsRdpEx_RdpOleHost_SetActive` is now bound in `RdpActiveXSession.EnsureOleHostExports` and driven from the view: UI-activate on `GotFocus`, UI-deactivate on `LostFocus`. Top-level window `Activated`/`Deactivated` is forwarded to `OnFrameWindowActivate` via a new additive `MsRdpEx_RdpOleHost_SetFrameActive` export (separate from `SetActive` because Avalonia retains logical focus on window deactivation, so frame deactivation must not UI-deactivate the control). Redundant `DoVerb(UIACTIVATE)` calls are suppressed by native UI-active state tracking (`m_uiActive`) plus a managed guard.
- **F2 — `OleUninitialize` could tear down OLE owned by Avalonia.** The actual `OleInitialize` HRESULT is now tracked: only `S_OK` counts as an owned initialization. A process-wide session refcount gates `OleUninitialize` so it only runs when we initialized OLE *and* no other `RdpActiveXSession` remains. If the owning session is disposed before later sessions, OLE intentionally stays initialized for the process lifetime rather than risking teardown underneath Avalonia's `OleContext` (which never uninitializes).
- **F3 — OLE frame window was the hidden off-screen HWND.** New additive export `MsRdpEx_RdpOleHost_SetFrameWindow` (plus `CRdpOleInPlaceSiteEx::SetFrameWindow`) reports the real Avalonia `TopLevel` HWND as `OLEINPLACEFRAMEINFO::hwndFrame`, so mstscax certificate/credential dialogs are parented to a visible window. The control itself stays parented to the off-screen surface; passing `NULL` falls back to the previous behavior. No existing export signatures changed.
- **F4 — Stuck keys/mouse buttons on window deactivation.** `Window.Deactivated` now releases all forwarded keys and mouse buttons (Avalonia retains logical focus, so `LostFocus` never fires in that case).

**Medium severity**

- **F5 — Host-app keyboard shortcuts were dead while the view was focused.** New `RdpClientView.LocalKeyFilter` delegate lets the hosting application (e.g. RDM) claim a key before it is forwarded; claimed keys pass through via `CallNextHookEx` and are never sent remotely. Consulted in both the low-level hook and the fallback `OnKeyDown`/`OnKeyUp` paths.
- **F8 — Non-deterministic RCW release.** Dispose ordering is now explicit on the UI thread: events unadvised → instance handle released → OLE host closes/de-sites the control natively → managed wrappers released. Built-in RCWs are released explicitly via `Marshal.FinalReleaseComObject`. Note: the generated interop wraps the control through `ComInterfaceMarshaller` (`StrategyBasedComWrappers`), which has no public deterministic-release API; the native close/de-site above is what makes the wrapper's final GC release inert, and this is documented in code.
- **F9 — Process-global `MSRDPEX_AXNAME`.** The previous value is now restored in a `finally` after activation completes (inside `NativeActivationLock`), with the cross-component constraint documented.
- **F10 — Keyboard trap while focused-but-disconnected.** The hook and the fallback key path now only swallow keys when a live connection exists (`IsConnectionActive`); otherwise keys pass through so Tab/focus traversal works.

**Low severity**

- **F11 — Raw vtable offsets in `MsRdpExInstanceHandle`.** Chosen fix: proper C-export wrappers mirroring the `OutputMirrorCapture_*` pattern — `MsRdpEx_Instance_SetOutputMirrorEnabled` and `MsRdpEx_Instance_GetInputWindow` — used whenever the native DLL exports them. The vtable paths remain only as fallbacks for older MsRdpEx builds (whose layout is frozen), matching the existing STA/capture compatibility design. This was picked over a layout-validation export because it removes the fragile indexing from the primary path entirely instead of just detecting breakage.
- **F13 — `EnumObjects` returned `E_NOTIMPL`.** Now returns an empty `IEnumUnknown` with `S_OK`, matching AxHost.

**Documented, not changed:** F6 (file drop stages `CF_HDROP` on the clipboard, replacing its content) and F7 (no remote→local pointer drag-out) are inherent to the bitmap-mirror approach and are now listed under "Known limitations" in the Avalonia README, along with the new public API (`LocalKeyFilter`, focus/activation behavior) and the Dispose contract (must be called on the UI thread; visual-tree detach intentionally keeps the session alive for docking).

## Verification

- Native Release x64 build clean (`cmake -G "Visual Studio 18 2026" -A x64 -DWITH_DOTNET=ON`), including DLL and all launcher EXEs
- `Devolutions.MsRdpEx.Avalonia` and `MsRdpEx_AvaloniaApp` build clean
- `MsRdpEx_Test`: **719/719 pass** (708 baseline + 11 new tests covering the `MSRDPEX_AXNAME` restore, the OLE init/teardown refcount rules, and the key pass-through truth table)

## Manual runtime verification (needs live RDP — for reviewers)

1. Connect to a server with an **untrusted cert** → certificate dialog visible, modal, and parented to the app window (F3). Same for credential prompts.
2. Focus in/out of the view and deactivate/reactivate the window → remote keys never stick (F1/F4); verify `FocusReleased` (Tab direction) still fires and moves focus in the host.
3. Clipboard: text, bitmap, and file copy **both directions**; confirm local clipboard is replaced by a file drop (documented F6); drag a file **out** of the remote session (expected unsupported, F7).
4. Host app accelerators while RDP focused with `LocalKeyFilter` set (F5); keyboard traversal on a disconnected-but-focused view (F10).
5. Two concurrent views; open/close repeatedly; verify Avalonia clipboard/DnD still works after the first view is disposed (F2); watch for RCW release hangs at shutdown (F8).
6. DPI: PerMonitorV2, mixed-DPI monitors, dynamic resolution on/off.
7. Keyboards: AltGr/international layouts, dead keys, IME via VK_PACKET, key repeat, Ctrl+Alt+End, Windows key (both `UseRemoteKeyboardShortcuts` modes).