### PR TITLE
Add hardware-mode output capture

### DIFF
--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -1,5 +1,7 @@
 
 #include "MsRdpEx.h"
+#include "D3D11Capture.h"
+#include "OutputMirrorCapture.h"
 #include "RdpInstanceInternal.h"
 
 #include <MsRdpEx/MsRdpEx.h>
@@ -430,10 +432,6 @@ bool WINAPI MsRdpEx_CaptureBlt(
     uint32_t frameHeight = 0;
     bool captured = false;
     bool outputMirrorEnabled = false;
-    bool videoRecordingEnabled = false;
-    uint32_t videoRecordingQuality = 5;
-    uint32_t videoRecordingFrameRate = 0;
-    bool dumpBitmapUpdates = false;
     IMsRdpExInstance* instance = NULL;
     MsRdpEx_OutputMirror* outputMirror = NULL;
     CMsRdpExtendedSettings* pExtendedSettings = NULL;
@@ -457,10 +455,6 @@ bool WINAPI MsRdpEx_CaptureBlt(
     MsRdpEx_LogPrint(TRACE, "CaptureBlt: hWnd: %p instance: %p", hWnd, instance);
 
     outputMirrorEnabled = pExtendedSettings->GetOutputMirrorEnabled();
-    videoRecordingEnabled = pExtendedSettings->GetVideoRecordingEnabled();
-    videoRecordingQuality = pExtendedSettings->GetVideoRecordingQuality();
-    videoRecordingFrameRate = pExtendedSettings->GetVideoRecordingFrameRate();
-    dumpBitmapUpdates = pExtendedSettings->GetDumpBitmapUpdates();
 
     if (!outputMirrorEnabled)
         goto end;
@@ -471,36 +465,9 @@ bool WINAPI MsRdpEx_CaptureBlt(
     LONG bitmapWidth = MsRdpEx_GetRectWidth(&rect);
     LONG bitmapHeight = MsRdpEx_GetRectHeight(&rect);
 
-    instance->GetOutputMirrorObject((LPVOID*) &outputMirror);
-
-    if (!outputMirror) 
-    {
-        outputMirror = MsRdpEx_OutputMirror_New();
-        MsRdpEx_OutputMirror_SetDumpBitmapUpdates(outputMirror, dumpBitmapUpdates);
-        MsRdpEx_OutputMirror_SetVideoRecordingEnabled(outputMirror, videoRecordingEnabled);
-        MsRdpEx_OutputMirror_SetVideoQualityLevel(outputMirror, videoRecordingQuality);
-        MsRdpEx_OutputMirror_SetVideoFrameRate(outputMirror, videoRecordingFrameRate);
-
-        char* recordingPath = pExtendedSettings->GetRecordingPath();
-        if (recordingPath) {
-            MsRdpEx_OutputMirror_SetRecordingPath(outputMirror, recordingPath);
-            free(recordingPath);
-        }
-
-        char* recordingPipeName = pExtendedSettings->GetRecordingPipeName();
-        if (recordingPipeName) {
-            MsRdpEx_OutputMirror_SetRecordingPipeName(outputMirror, recordingPipeName);
-            free(recordingPipeName);
-        }
-
-		const char* sessionId = pExtendedSettings->GetRecordingSessionId();
-        if (!sessionId) {
-            sessionId = pExtendedSettings->GetSessionId();
-        }
-        MsRdpEx_OutputMirror_SetSessionId(outputMirror, sessionId);
-
-        instance->SetOutputMirrorObject((LPVOID) outputMirror);
-    }
+    outputMirror = MsRdpEx_OutputMirror_GetOrCreate(instance, pExtendedSettings);
+    if (!outputMirror)
+        goto end;
 
     MsRdpEx_OutputMirror_GetFrameSize(outputMirror, &frameWidth, &frameHeight);
 
@@ -511,16 +478,27 @@ bool WINAPI MsRdpEx_CaptureBlt(
         MsRdpEx_OutputMirror_Uninit(outputMirror);
         MsRdpEx_OutputMirror_SetSourceDC(outputMirror, hdcSrc);
         MsRdpEx_OutputMirror_SetFrameSize(outputMirror, bitmapWidth, bitmapHeight);
-        MsRdpEx_OutputMirror_Init(outputMirror);
+        if (!MsRdpEx_OutputMirror_Init(outputMirror))
+        {
+            MsRdpEx_OutputMirror_Unlock(outputMirror);
+            goto end;
+        }
     }
 
     HDC hShadowDC = MsRdpEx_OutputMirror_GetShadowDC(outputMirror);
+    if (!hShadowDC)
+    {
+        MsRdpEx_OutputMirror_Unlock(outputMirror);
+        goto end;
+    }
+
     BitBlt(hShadowDC, dstX, dstY, width, height, hdcSrc, srcX, srcY, SRCCOPY);
 
     instance->DumpFrameWithCursor();
     MsRdpEx_OutputMirror_Unlock(outputMirror);
 
     captured = true;
+    MsRdpEx_Instance_NotifyOutputFrame(instance);
 end:
     if (instance)
         instance->Release();
@@ -700,6 +678,18 @@ LRESULT CALLBACK Hook_OPWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
             }
         }
 	}
+	else if (uMsg == MsRdpEx_Instance_GetGdiReconnectMessage())
+	{
+	    IMsRdpExInstance* reconnectInstance = (IMsRdpExInstance*)
+	        MsRdpEx_InstanceManager_FindByOutputPresenterHwnd(hWnd);
+	    MsRdpEx_Instance_ReconnectUsingGdi(reconnectInstance);
+	}
+    else if (uMsg == WM_TIMER && wParam == MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId())
+    {
+        IMsRdpExInstance* watchdogInstance = (IMsRdpExInstance*)
+            MsRdpEx_InstanceManager_FindByOutputPresenterHwnd(hWnd);
+        MsRdpEx_Instance_HandleHardwareCaptureWatchdog(watchdogInstance);
+    }
 
 	free(lpWindowNameA);
 
@@ -1662,6 +1652,7 @@ LONG MsRdpEx_AttachHooks()
     //MSRDPEX_DETOUR_ATTACH(Real_RegCloseKey, Hook_RegCloseKey);
 
     MSRDPEX_DETOUR_ATTACH(Real_DeleteMenu, Hook_DeleteMenu);
+    MsRdpEx_D3D11Capture_AttachHooks();
     
     MsRdpEx_AttachSspiHooks();
     error = DetourTransactionCommit();
@@ -1721,6 +1712,7 @@ LONG MsRdpEx_DetachHooks()
     //MSRDPEX_DETOUR_DETACH(Real_RegCloseKey, Hook_RegCloseKey);
 
     MSRDPEX_DETOUR_DETACH(Real_DeleteMenu, Hook_DeleteMenu);
+    MsRdpEx_D3D11Capture_DetachHooks();
     
     MsRdpEx_DetachSspiHooks();
     error = DetourTransactionCommit();
@@ -1730,6 +1722,7 @@ LONG MsRdpEx_DetachHooks()
         g_IsHooked = false;
     }
 
+    MsRdpEx_D3D11Capture_Shutdown();
     MsRdpEx_GlobalUninit();
     return error;
 }

--- a/dll/ApiHooks.cpp
+++ b/dll/ApiHooks.cpp
@@ -480,6 +480,7 @@ bool WINAPI MsRdpEx_CaptureBlt(
         MsRdpEx_OutputMirror_SetFrameSize(outputMirror, bitmapWidth, bitmapHeight);
         if (!MsRdpEx_OutputMirror_Init(outputMirror))
         {
+            MsRdpEx_OutputMirror_SetFrameSize(outputMirror, 0, 0);
             MsRdpEx_OutputMirror_Unlock(outputMirror);
             goto end;
         }
@@ -1720,9 +1721,9 @@ LONG MsRdpEx_DetachHooks()
     if (error == NO_ERROR)
     {
         g_IsHooked = false;
+        MsRdpEx_D3D11Capture_Shutdown();
     }
 
-    MsRdpEx_D3D11Capture_Shutdown();
     MsRdpEx_GlobalUninit();
     return error;
 }

--- a/dll/CMakeLists.txt
+++ b/dll/CMakeLists.txt
@@ -58,9 +58,13 @@ set(MSRDPEX_SOURCES
     MsRdpClient.cpp
     MsRdpClient.h
     ApiHooks.cpp
+    D3D11Capture.cpp
+    D3D11Capture.h
     CursorOverlay.c
     CursorOverlay.h
     OutputMirror.c
+    OutputMirrorCapture.cpp
+    OutputMirrorCapture.h
     VideoRecorder.c
     RecordingManifest.c
     NamedPipe.c
@@ -115,7 +119,9 @@ set(MSRDPEX_LIBS
     advapi32.lib
     crypt32.lib
     comctl32.lib
-    ole32.lib)
+    ole32.lib
+    d3d11.lib
+    dxgi.lib)
 
 target_compile_options(MsRdpEx_Dll PRIVATE /W4)
 

--- a/dll/D3D11Capture.cpp
+++ b/dll/D3D11Capture.cpp
@@ -1,0 +1,742 @@
+#include "MsRdpEx.h"
+#include "D3D11Capture.h"
+#include "OutputMirrorCapture.h"
+
+#include <MsRdpEx/Detours.h>
+
+#include <d3d11.h>
+#include <dxgi1_2.h>
+
+#include <vector>
+
+typedef HRESULT(WINAPI* D3D11CreateDeviceFn)(
+    IDXGIAdapter* adapter,
+    D3D_DRIVER_TYPE driverType,
+    HMODULE software,
+    UINT flags,
+    const D3D_FEATURE_LEVEL* featureLevels,
+    UINT featureLevelsCount,
+    UINT sdkVersion,
+    ID3D11Device** device,
+    D3D_FEATURE_LEVEL* featureLevel,
+    ID3D11DeviceContext** immediateContext);
+
+typedef HRESULT(STDMETHODCALLTYPE* CreateCompositionSwapChainFn)(
+    IDXGIFactory2* factory,
+    IUnknown* device,
+    const DXGI_SWAP_CHAIN_DESC1* description,
+    IDXGIOutput* restrictToOutput,
+    IDXGISwapChain1** swapChain);
+
+typedef HRESULT(STDMETHODCALLTYPE* SwapChainPresentFn)(
+    IDXGISwapChain* swapChain,
+    UINT syncInterval,
+    UINT flags);
+
+typedef ULONG(STDMETHODCALLTYPE* SwapChainReleaseFn)(IDXGISwapChain* swapChain);
+
+struct MsRdpEx_D3D11CaptureDevice
+{
+    ID3D11Device* device;
+    IMsRdpExInstance* instance;
+};
+
+struct MsRdpEx_D3D11CaptureSwapChain
+{
+    IDXGISwapChain* swapChain;
+    ID3D11Device* device;
+    ID3D11DeviceContext* context;
+    ID3D11Texture2D* stagingTexture;
+    IMsRdpExInstance* instance;
+    UINT width;
+    UINT height;
+    DXGI_FORMAT format;
+    bool unavailable;
+};
+
+static SRWLOCK g_D3D11CaptureLock = SRWLOCK_INIT;
+static std::vector<IMsRdpExInstance*> g_PendingInstances;
+static std::vector<MsRdpEx_D3D11CaptureDevice> g_Devices;
+static std::vector<MsRdpEx_D3D11CaptureSwapChain> g_SwapChains;
+
+static D3D11CreateDeviceFn Real_D3D11CreateDevice = D3D11CreateDevice;
+static CreateCompositionSwapChainFn Real_CreateCompositionSwapChain = NULL;
+static SwapChainPresentFn Real_SwapChainPresent = NULL;
+static SwapChainReleaseFn Real_SwapChainRelease = NULL;
+
+static bool g_CreateCompositionSwapChainHookAttached = false;
+static bool g_SwapChainPresentHookAttached = false;
+static bool g_SwapChainReleaseHookAttached = false;
+static PVOID g_CreateCompositionSwapChainTarget = NULL;
+static PVOID g_SwapChainPresentTarget = NULL;
+static PVOID g_SwapChainReleaseTarget = NULL;
+static thread_local LONG g_D3D11CaptureDepth = 0;
+
+static HRESULT STDMETHODCALLTYPE Hook_CreateCompositionSwapChain(
+    IDXGIFactory2* factory,
+    IUnknown* device,
+    const DXGI_SWAP_CHAIN_DESC1* description,
+    IDXGIOutput* restrictToOutput,
+    IDXGISwapChain1** swapChain);
+
+static HRESULT STDMETHODCALLTYPE Hook_SwapChainPresent(
+    IDXGISwapChain* swapChain,
+    UINT syncInterval,
+    UINT flags);
+
+static ULONG STDMETHODCALLTYPE Hook_SwapChainRelease(IDXGISwapChain* swapChain);
+static void MsRdpEx_D3D11Capture_DisableHardwareMode(
+    IMsRdpExInstance* instance,
+    const char* operation,
+    HRESULT error);
+
+static void MsRdpEx_D3D11Capture_ReleaseSwapChain(
+    MsRdpEx_D3D11CaptureSwapChain* swapChain)
+{
+    if (swapChain->stagingTexture)
+        swapChain->stagingTexture->Release();
+    if (swapChain->context)
+        swapChain->context->Release();
+    if (swapChain->device)
+        swapChain->device->Release();
+    if (swapChain->instance)
+        swapChain->instance->Release();
+}
+
+static void MsRdpEx_D3D11Capture_RemoveSwapChain(IDXGISwapChain* swapChain)
+{
+    AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+    for (size_t i = 0; i < g_SwapChains.size(); i++)
+    {
+        if (g_SwapChains[i].swapChain == swapChain)
+        {
+            MsRdpEx_D3D11Capture_ReleaseSwapChain(&g_SwapChains[i]);
+            g_SwapChains.erase(g_SwapChains.begin() + i);
+            break;
+        }
+    }
+    ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+}
+
+static IMsRdpExInstance* MsRdpEx_D3D11Capture_FindInstanceForDevice(IUnknown* device)
+{
+    IMsRdpExInstance* instance = NULL;
+    ID3D11Device* d3dDevice = NULL;
+
+    if (!device ||
+        FAILED(device->QueryInterface(__uuidof(ID3D11Device), (void**)&d3dDevice)))
+        return NULL;
+
+    AcquireSRWLockShared(&g_D3D11CaptureLock);
+    for (const MsRdpEx_D3D11CaptureDevice& entry : g_Devices)
+    {
+        if (entry.device == d3dDevice)
+        {
+            instance = entry.instance;
+            instance->AddRef();
+            break;
+        }
+    }
+    ReleaseSRWLockShared(&g_D3D11CaptureLock);
+    d3dDevice->Release();
+
+    return instance;
+}
+
+static IMsRdpExInstance* MsRdpEx_D3D11Capture_FindPendingInstance()
+{
+    IMsRdpExInstance* instance = NULL;
+
+    AcquireSRWLockShared(&g_D3D11CaptureLock);
+    if (g_PendingInstances.size() == 1)
+    {
+        instance = g_PendingInstances.front();
+        instance->AddRef();
+    }
+    ReleaseSRWLockShared(&g_D3D11CaptureLock);
+
+    return instance;
+}
+
+static bool MsRdpEx_D3D11Capture_AttachDynamicHook(
+    PVOID* realFunction,
+    PVOID hookFunction,
+    bool* attached)
+{
+    LONG error;
+
+    if (*attached)
+        return true;
+
+    error = DetourTransactionBegin();
+    if (error != NO_ERROR)
+        return false;
+
+    DetourUpdateThread(GetCurrentThread());
+    error = DetourAttach(realFunction, hookFunction);
+    if (error == NO_ERROR)
+        error = DetourTransactionCommit();
+    else
+        DetourTransactionAbort();
+
+    if (error == NO_ERROR)
+        *attached = true;
+
+    return error == NO_ERROR;
+}
+
+static bool MsRdpEx_D3D11Capture_AttachSwapChainHooks(IDXGISwapChain* swapChain)
+{
+    void** vtable = *(void***)swapChain;
+
+    AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+
+    if (!g_SwapChainPresentHookAttached)
+    {
+        Real_SwapChainPresent = (SwapChainPresentFn)vtable[8];
+        g_SwapChainPresentTarget = (PVOID)Real_SwapChainPresent;
+        if (!MsRdpEx_D3D11Capture_AttachDynamicHook(
+            (PVOID*)&Real_SwapChainPresent, (PVOID)Hook_SwapChainPresent,
+            &g_SwapChainPresentHookAttached))
+        {
+            Real_SwapChainPresent = NULL;
+            ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+            return false;
+        }
+    }
+    else if (vtable[8] != g_SwapChainPresentTarget)
+    {
+        ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+        return false;
+    }
+
+    if (!g_SwapChainReleaseHookAttached)
+    {
+        Real_SwapChainRelease = (SwapChainReleaseFn)vtable[2];
+        g_SwapChainReleaseTarget = (PVOID)Real_SwapChainRelease;
+        if (!MsRdpEx_D3D11Capture_AttachDynamicHook(
+            (PVOID*)&Real_SwapChainRelease, (PVOID)Hook_SwapChainRelease,
+            &g_SwapChainReleaseHookAttached))
+        {
+            Real_SwapChainRelease = NULL;
+            ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+            return false;
+        }
+    }
+    else if (vtable[2] != g_SwapChainReleaseTarget)
+    {
+        ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+        return false;
+    }
+
+    ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+    return true;
+}
+
+static void MsRdpEx_D3D11Capture_TrackSwapChain(
+    IUnknown* device,
+    IDXGISwapChain1* swapChain)
+{
+    IMsRdpExInstance* instance = MsRdpEx_D3D11Capture_FindInstanceForDevice(device);
+    if (!instance)
+    {
+        instance = MsRdpEx_D3D11Capture_FindPendingInstance();
+        if (instance)
+        {
+            MsRdpEx_D3D11Capture_DisableHardwareMode(
+                instance, "attribute composition swap chain to RDP device", E_FAIL);
+            instance->Release();
+        }
+        return;
+    }
+
+    ID3D11Device* d3dDevice = NULL;
+    ID3D11DeviceContext* context = NULL;
+
+    HRESULT hr = swapChain->GetDevice(__uuidof(ID3D11Device), (void**)&d3dDevice);
+    if (FAILED(hr))
+    {
+        MsRdpEx_D3D11Capture_DisableHardwareMode(
+            instance, "query composition swap-chain device", hr);
+        instance->Release();
+        return;
+    }
+
+    d3dDevice->GetImmediateContext(&context);
+    if (!context || !MsRdpEx_D3D11Capture_AttachSwapChainHooks(swapChain))
+    {
+        MsRdpEx_D3D11Capture_DisableHardwareMode(
+            instance, "hook RDP composition swap chain", E_FAIL);
+        if (context)
+            context->Release();
+        d3dDevice->Release();
+        instance->Release();
+        return;
+    }
+
+    MsRdpEx_D3D11CaptureSwapChain entry = {};
+    entry.swapChain = swapChain;
+    entry.device = d3dDevice;
+    entry.context = context;
+    entry.instance = instance;
+
+    AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+    g_SwapChains.push_back(entry);
+    ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+}
+
+static void MsRdpEx_D3D11Capture_DisableHardwareMode(
+    IMsRdpExInstance* instance,
+    const char* operation,
+    HRESULT error)
+{
+    MsRdpEx_LogPrint(ERROR,
+        "D3D11 capture %s failed: 0x%08X; reconnecting with GDI presentation",
+        operation, error);
+
+    if (!MsRdpEx_Instance_RequestGdiReconnect(instance))
+    {
+        MsRdpEx_LogPrint(ERROR,
+            "D3D11 capture could not schedule the GDI fallback reconnect");
+    }
+}
+
+static void MsRdpEx_D3D11Capture_MarkUnavailable(
+    MsRdpEx_D3D11CaptureSwapChain* swapChain,
+    const char* operation,
+    HRESULT error)
+{
+    if (swapChain->unavailable)
+        return;
+
+    swapChain->unavailable = true;
+    MsRdpEx_D3D11Capture_DisableHardwareMode(
+        swapChain->instance, operation, error);
+}
+
+static bool MsRdpEx_D3D11Capture_CopySwapChainPixels(
+    MsRdpEx_D3D11CaptureSwapChain* swapChain,
+    std::vector<uint8_t>* pixels,
+    UINT* width,
+    UINT* height)
+{
+    ID3D11Texture2D* backBuffer = NULL;
+    D3D11_TEXTURE2D_DESC description = {};
+    D3D11_MAPPED_SUBRESOURCE mapped = {};
+    HRESULT hr;
+
+    if (swapChain->unavailable)
+        return false;
+
+    hr = swapChain->swapChain->GetBuffer(
+        0, __uuidof(ID3D11Texture2D), (void**)&backBuffer);
+    if (FAILED(hr))
+    {
+        MsRdpEx_D3D11Capture_MarkUnavailable(swapChain, "GetBuffer", hr);
+        return false;
+    }
+
+    backBuffer->GetDesc(&description);
+    if ((description.Format != DXGI_FORMAT_B8G8R8A8_UNORM &&
+         description.Format != DXGI_FORMAT_B8G8R8A8_UNORM_SRGB &&
+         description.Format != DXGI_FORMAT_B8G8R8X8_UNORM &&
+         description.Format != DXGI_FORMAT_B8G8R8X8_UNORM_SRGB) ||
+        description.SampleDesc.Count != 1)
+    {
+        MsRdpEx_D3D11Capture_MarkUnavailable(
+            swapChain, "unsupported backbuffer format", E_NOTIMPL);
+        backBuffer->Release();
+        return false;
+    }
+
+    if (!swapChain->stagingTexture ||
+        swapChain->width != description.Width ||
+        swapChain->height != description.Height ||
+        swapChain->format != description.Format)
+    {
+        if (swapChain->stagingTexture)
+        {
+            swapChain->stagingTexture->Release();
+            swapChain->stagingTexture = NULL;
+        }
+
+        description.Usage = D3D11_USAGE_STAGING;
+        description.BindFlags = 0;
+        description.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        description.MiscFlags = 0;
+
+        hr = swapChain->device->CreateTexture2D(
+            &description, NULL, &swapChain->stagingTexture);
+        if (FAILED(hr))
+        {
+            MsRdpEx_D3D11Capture_MarkUnavailable(swapChain, "CreateTexture2D", hr);
+            backBuffer->Release();
+            return false;
+        }
+
+        swapChain->width = description.Width;
+        swapChain->height = description.Height;
+        swapChain->format = description.Format;
+    }
+
+    swapChain->context->CopyResource(swapChain->stagingTexture, backBuffer);
+    hr = swapChain->context->Map(
+        swapChain->stagingTexture, 0, D3D11_MAP_READ, 0, &mapped);
+    if (FAILED(hr))
+    {
+        MsRdpEx_D3D11Capture_MarkUnavailable(swapChain, "Map", hr);
+        backBuffer->Release();
+        return false;
+    }
+
+    pixels->resize((size_t)swapChain->width * swapChain->height * 4);
+    for (UINT y = 0; y < swapChain->height; y++)
+    {
+        memcpy(pixels->data() + (size_t)y * swapChain->width * 4,
+            (const uint8_t*)mapped.pData + (size_t)y * mapped.RowPitch,
+            (size_t)swapChain->width * 4);
+    }
+
+    swapChain->context->Unmap(swapChain->stagingTexture, 0);
+    backBuffer->Release();
+    *width = swapChain->width;
+    *height = swapChain->height;
+    return true;
+}
+
+static HRESULT STDMETHODCALLTYPE Hook_CreateCompositionSwapChain(
+    IDXGIFactory2* factory,
+    IUnknown* device,
+    const DXGI_SWAP_CHAIN_DESC1* description,
+    IDXGIOutput* restrictToOutput,
+    IDXGISwapChain1** swapChain)
+{
+    HRESULT hr = Real_CreateCompositionSwapChain(
+        factory, device, description, restrictToOutput, swapChain);
+
+    if (SUCCEEDED(hr) && swapChain && *swapChain &&
+        MsRdpEx_IsAddressInRdpAxModule(_ReturnAddress()))
+    {
+        MsRdpEx_D3D11Capture_TrackSwapChain(device, *swapChain);
+    }
+
+    return hr;
+}
+
+static HRESULT STDMETHODCALLTYPE Hook_SwapChainPresent(
+    IDXGISwapChain* swapChain,
+    UINT syncInterval,
+    UINT flags)
+{
+    if (g_D3D11CaptureDepth == 0)
+    {
+        g_D3D11CaptureDepth++;
+        std::vector<uint8_t> pixels;
+        IMsRdpExInstance* instance = NULL;
+        UINT width = 0;
+        UINT height = 0;
+        bool copied = false;
+
+        AcquireSRWLockShared(&g_D3D11CaptureLock);
+        for (MsRdpEx_D3D11CaptureSwapChain& entry : g_SwapChains)
+        {
+            if (entry.swapChain == swapChain)
+            {
+                entry.instance->AddRef();
+                instance = entry.instance;
+                copied = MsRdpEx_D3D11Capture_CopySwapChainPixels(
+                    &entry, &pixels, &width, &height);
+                break;
+            }
+        }
+        ReleaseSRWLockShared(&g_D3D11CaptureLock);
+
+        if (copied)
+        {
+            bool outputMirrorEnabled = false;
+            const HRESULT enabledHr =
+                instance->GetOutputMirrorEnabled(&outputMirrorEnabled);
+            const bool captured = SUCCEEDED(enabledHr) && outputMirrorEnabled &&
+                MsRdpEx_OutputMirror_CapturePixels(
+                    instance, pixels.data(), width, height, width * 4);
+
+            if (captured)
+            {
+                MsRdpEx_Instance_NotifyOutputFrame(instance);
+            }
+            else if (SUCCEEDED(enabledHr) && outputMirrorEnabled)
+            {
+                AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+                for (MsRdpEx_D3D11CaptureSwapChain& entry : g_SwapChains)
+                {
+                    if (entry.swapChain == swapChain)
+                    {
+                        MsRdpEx_D3D11Capture_MarkUnavailable(
+                            &entry, "upload output mirror pixels", E_FAIL);
+                        break;
+                    }
+                }
+                ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+            }
+        }
+
+        if (instance)
+            instance->Release();
+
+        g_D3D11CaptureDepth--;
+    }
+
+    return Real_SwapChainPresent(swapChain, syncInterval, flags);
+}
+
+static ULONG STDMETHODCALLTYPE Hook_SwapChainRelease(IDXGISwapChain* swapChain)
+{
+    swapChain->AddRef();
+    const ULONG refCount = Real_SwapChainRelease(swapChain);
+    if (refCount == 1)
+        MsRdpEx_D3D11Capture_RemoveSwapChain(swapChain);
+    return Real_SwapChainRelease(swapChain);
+}
+
+static void MsRdpEx_D3D11Capture_TrackDevice(ID3D11Device* device)
+{
+    IMsRdpExInstance* instance = MsRdpEx_D3D11Capture_FindPendingInstance();
+    if (!instance)
+        return;
+
+    AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+    for (const MsRdpEx_D3D11CaptureDevice& entry : g_Devices)
+    {
+        if (entry.device == device)
+        {
+            ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+            instance->Release();
+            return;
+        }
+    }
+
+    device->AddRef();
+    instance->AddRef();
+    g_Devices.push_back({ device, instance });
+    ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+
+    IDXGIDevice* dxgiDevice = NULL;
+    IDXGIAdapter* adapter = NULL;
+    IDXGIFactory2* factory = NULL;
+
+    HRESULT hr = device->QueryInterface(__uuidof(IDXGIDevice), (void**)&dxgiDevice);
+    if (SUCCEEDED(hr))
+        hr = dxgiDevice->GetAdapter(&adapter);
+    if (SUCCEEDED(hr))
+        hr = adapter->GetParent(__uuidof(IDXGIFactory2), (void**)&factory);
+
+    if (SUCCEEDED(hr))
+    {
+        void** vtable = *(void***)factory;
+
+        AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+        if (!g_CreateCompositionSwapChainHookAttached)
+        {
+            Real_CreateCompositionSwapChain = (CreateCompositionSwapChainFn)vtable[24];
+            g_CreateCompositionSwapChainTarget = (PVOID)Real_CreateCompositionSwapChain;
+            if (!MsRdpEx_D3D11Capture_AttachDynamicHook(
+                (PVOID*)&Real_CreateCompositionSwapChain,
+                (PVOID)Hook_CreateCompositionSwapChain,
+                &g_CreateCompositionSwapChainHookAttached))
+            {
+                Real_CreateCompositionSwapChain = NULL;
+                MsRdpEx_D3D11Capture_DisableHardwareMode(
+                    instance, "hook IDXGIFactory2::CreateSwapChainForComposition", E_FAIL);
+            }
+        }
+        else if (vtable[24] != g_CreateCompositionSwapChainTarget)
+        {
+            MsRdpEx_D3D11Capture_DisableHardwareMode(
+                instance, "unsupported IDXGIFactory2 implementation", E_NOTIMPL);
+        }
+        ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+    }
+    else
+    {
+        MsRdpEx_D3D11Capture_DisableHardwareMode(
+            instance, "locate the RDP composition factory", hr);
+    }
+
+    if (factory)
+        factory->Release();
+    if (adapter)
+        adapter->Release();
+    if (dxgiDevice)
+        dxgiDevice->Release();
+    instance->Release();
+}
+
+static HRESULT WINAPI Hook_D3D11CreateDevice(
+    IDXGIAdapter* adapter,
+    D3D_DRIVER_TYPE driverType,
+    HMODULE software,
+    UINT flags,
+    const D3D_FEATURE_LEVEL* featureLevels,
+    UINT featureLevelsCount,
+    UINT sdkVersion,
+    ID3D11Device** device,
+    D3D_FEATURE_LEVEL* featureLevel,
+    ID3D11DeviceContext** immediateContext)
+{
+    const HRESULT hr = Real_D3D11CreateDevice(
+        adapter, driverType, software, flags, featureLevels, featureLevelsCount,
+        sdkVersion, device, featureLevel, immediateContext);
+
+    if (SUCCEEDED(hr) && device && *device &&
+        MsRdpEx_IsAddressInRdpAxModule(_ReturnAddress()))
+    {
+        MsRdpEx_D3D11Capture_TrackDevice(*device);
+    }
+
+    return hr;
+}
+
+void MsRdpEx_D3D11Capture_RegisterPendingInstance(IMsRdpExInstance* instance)
+{
+    if (!instance)
+        return;
+
+    bool anotherInstanceIsTracked = false;
+
+    AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+    for (IMsRdpExInstance* pendingInstance : g_PendingInstances)
+    {
+        if (pendingInstance == instance)
+        {
+            ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+            return;
+        }
+
+        anotherInstanceIsTracked = true;
+    }
+
+    for (const MsRdpEx_D3D11CaptureDevice& device : g_Devices)
+    {
+        if (device.instance != instance)
+        {
+            anotherInstanceIsTracked = true;
+            break;
+        }
+    }
+
+    for (const MsRdpEx_D3D11CaptureSwapChain& swapChain : g_SwapChains)
+    {
+        if (swapChain.instance != instance)
+        {
+            anotherInstanceIsTracked = true;
+            break;
+        }
+    }
+
+    bool registered = false;
+    if (!anotherInstanceIsTracked)
+    {
+        instance->AddRef();
+        g_PendingInstances.push_back(instance);
+        registered = true;
+    }
+    ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+
+    if (anotherInstanceIsTracked)
+    {
+        MsRdpEx_D3D11Capture_DisableHardwareMode(
+            instance, "multiple simultaneous hardware capture sessions", E_NOTIMPL);
+    }
+    else if (registered && !MsRdpEx_Instance_ArmHardwareCaptureWatchdog(instance))
+    {
+        MsRdpEx_D3D11Capture_DisableHardwareMode(
+            instance, "arm hardware capture watchdog", HRESULT_FROM_WIN32(GetLastError()));
+    }
+}
+
+void MsRdpEx_D3D11Capture_ReleaseInstance(IMsRdpExInstance* instance)
+{
+    if (!instance)
+        return;
+
+    MsRdpEx_Instance_DisarmHardwareCaptureWatchdog(instance);
+
+    AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+
+    for (size_t i = g_SwapChains.size(); i > 0; i--)
+    {
+        const size_t index = i - 1;
+        if (g_SwapChains[index].instance == instance)
+        {
+            MsRdpEx_D3D11Capture_ReleaseSwapChain(&g_SwapChains[index]);
+            g_SwapChains.erase(g_SwapChains.begin() + index);
+        }
+    }
+
+    for (size_t i = g_Devices.size(); i > 0; i--)
+    {
+        const size_t index = i - 1;
+        if (g_Devices[index].instance == instance)
+        {
+            g_Devices[index].device->Release();
+            g_Devices[index].instance->Release();
+            g_Devices.erase(g_Devices.begin() + index);
+        }
+    }
+
+    for (size_t i = 0; i < g_PendingInstances.size(); i++)
+    {
+        if (g_PendingInstances[i] == instance)
+        {
+            g_PendingInstances[i]->Release();
+            g_PendingInstances.erase(g_PendingInstances.begin() + i);
+            break;
+        }
+    }
+    ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+}
+
+void MsRdpEx_D3D11Capture_AttachHooks()
+{
+    MSRDPEX_DETOUR_ATTACH(Real_D3D11CreateDevice, Hook_D3D11CreateDevice);
+}
+
+void MsRdpEx_D3D11Capture_DetachHooks()
+{
+    MSRDPEX_DETOUR_DETACH(Real_D3D11CreateDevice, Hook_D3D11CreateDevice);
+    MSRDPEX_DETOUR_DETACH(Real_CreateCompositionSwapChain, Hook_CreateCompositionSwapChain);
+    MSRDPEX_DETOUR_DETACH(Real_SwapChainPresent, Hook_SwapChainPresent);
+    MSRDPEX_DETOUR_DETACH(Real_SwapChainRelease, Hook_SwapChainRelease);
+}
+
+void MsRdpEx_D3D11Capture_Shutdown()
+{
+    AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+
+    for (MsRdpEx_D3D11CaptureSwapChain& swapChain : g_SwapChains)
+        MsRdpEx_D3D11Capture_ReleaseSwapChain(&swapChain);
+    g_SwapChains.clear();
+
+    for (MsRdpEx_D3D11CaptureDevice& device : g_Devices)
+    {
+        device.device->Release();
+        device.instance->Release();
+    }
+    g_Devices.clear();
+
+    for (IMsRdpExInstance* instance : g_PendingInstances)
+        instance->Release();
+    g_PendingInstances.clear();
+
+    g_CreateCompositionSwapChainHookAttached = false;
+    g_SwapChainPresentHookAttached = false;
+    g_SwapChainReleaseHookAttached = false;
+    g_CreateCompositionSwapChainTarget = NULL;
+    g_SwapChainPresentTarget = NULL;
+    g_SwapChainReleaseTarget = NULL;
+    Real_CreateCompositionSwapChain = NULL;
+    Real_SwapChainPresent = NULL;
+    Real_SwapChainRelease = NULL;
+
+    ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+}

--- a/dll/D3D11Capture.cpp
+++ b/dll/D3D11Capture.cpp
@@ -52,6 +52,7 @@ struct MsRdpEx_D3D11CaptureSwapChain
     UINT height;
     DXGI_FORMAT format;
     bool unavailable;
+    bool captureStarted;
 };
 
 static SRWLOCK g_D3D11CaptureLock = SRWLOCK_INIT;
@@ -283,6 +284,16 @@ static void MsRdpEx_D3D11Capture_TrackSwapChain(
     AcquireSRWLockExclusive(&g_D3D11CaptureLock);
     g_SwapChains.push_back(entry);
     ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+
+    MsRdpEx_LogPrint(DEBUG,
+        "D3D11 capture tracking RDP composition swap chain: %p", swapChain);
+
+    if (!MsRdpEx_Instance_ArmHardwareCaptureWatchdog(instance))
+    {
+        MsRdpEx_D3D11Capture_DisableHardwareMode(
+            instance, "arm hardware capture watchdog",
+            HRESULT_FROM_WIN32(GetLastError()));
+    }
 }
 
 static void MsRdpEx_D3D11Capture_DisableHardwareMode(
@@ -414,8 +425,9 @@ static HRESULT STDMETHODCALLTYPE Hook_CreateCompositionSwapChain(
     HRESULT hr = Real_CreateCompositionSwapChain(
         factory, device, description, restrictToOutput, swapChain);
 
-    if (SUCCEEDED(hr) && swapChain && *swapChain &&
-        MsRdpEx_IsAddressInRdpAxModule(_ReturnAddress()))
+    // DirectComposition can invoke the factory from outside mstscax.dll.
+    // Device attribution below keeps this limited to an RDP-owned device.
+    if (SUCCEEDED(hr) && swapChain && *swapChain)
     {
         MsRdpEx_D3D11Capture_TrackSwapChain(device, *swapChain);
     }
@@ -437,7 +449,7 @@ static HRESULT STDMETHODCALLTYPE Hook_SwapChainPresent(
         UINT height = 0;
         bool copied = false;
 
-        AcquireSRWLockShared(&g_D3D11CaptureLock);
+        AcquireSRWLockExclusive(&g_D3D11CaptureLock);
         for (MsRdpEx_D3D11CaptureSwapChain& entry : g_SwapChains)
         {
             if (entry.swapChain == swapChain)
@@ -449,7 +461,7 @@ static HRESULT STDMETHODCALLTYPE Hook_SwapChainPresent(
                 break;
             }
         }
-        ReleaseSRWLockShared(&g_D3D11CaptureLock);
+        ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
 
         if (copied)
         {
@@ -462,6 +474,24 @@ static HRESULT STDMETHODCALLTYPE Hook_SwapChainPresent(
 
             if (captured)
             {
+                bool firstCapture = false;
+                AcquireSRWLockExclusive(&g_D3D11CaptureLock);
+                for (MsRdpEx_D3D11CaptureSwapChain& entry : g_SwapChains)
+                {
+                    if (entry.swapChain == swapChain && !entry.captureStarted)
+                    {
+                        entry.captureStarted = true;
+                        firstCapture = true;
+                        break;
+                    }
+                }
+                ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+
+                if (firstCapture)
+                {
+                    MsRdpEx_LogPrint(DEBUG,
+                        "D3D11 capture received the first hardware frame");
+                }
                 MsRdpEx_Instance_NotifyOutputFrame(instance);
             }
             else if (SUCCEEDED(enabledHr) && outputMirrorEnabled)
@@ -519,6 +549,8 @@ static void MsRdpEx_D3D11Capture_TrackDevice(ID3D11Device* device)
     instance->AddRef();
     g_Devices.push_back({ device, instance });
     ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+
+    MsRdpEx_LogPrint(DEBUG, "D3D11 capture tracking RDP device: %p", device);
 
     IDXGIDevice* dxgiDevice = NULL;
     IDXGIAdapter* adapter = NULL;
@@ -590,6 +622,8 @@ static HRESULT WINAPI Hook_D3D11CreateDevice(
     if (SUCCEEDED(hr) && device && *device &&
         MsRdpEx_IsAddressInRdpAxModule(_ReturnAddress()))
     {
+        MsRdpEx_LogPrint(DEBUG,
+            "D3D11CreateDevice returned for RDP ActiveX: %p", *device);
         MsRdpEx_D3D11Capture_TrackDevice(*device);
     }
 
@@ -633,12 +667,10 @@ void MsRdpEx_D3D11Capture_RegisterPendingInstance(IMsRdpExInstance* instance)
         }
     }
 
-    bool registered = false;
     if (!anotherInstanceIsTracked)
     {
         instance->AddRef();
         g_PendingInstances.push_back(instance);
-        registered = true;
     }
     ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
 
@@ -646,11 +678,6 @@ void MsRdpEx_D3D11Capture_RegisterPendingInstance(IMsRdpExInstance* instance)
     {
         MsRdpEx_D3D11Capture_DisableHardwareMode(
             instance, "multiple simultaneous hardware capture sessions", E_NOTIMPL);
-    }
-    else if (registered && !MsRdpEx_Instance_ArmHardwareCaptureWatchdog(instance))
-    {
-        MsRdpEx_D3D11Capture_DisableHardwareMode(
-            instance, "arm hardware capture watchdog", HRESULT_FROM_WIN32(GetLastError()));
     }
 }
 
@@ -725,7 +752,10 @@ void MsRdpEx_D3D11Capture_Shutdown()
     g_Devices.clear();
 
     for (IMsRdpExInstance* instance : g_PendingInstances)
+    {
+        MsRdpEx_Instance_DisarmHardwareCaptureWatchdog(instance);
         instance->Release();
+    }
     g_PendingInstances.clear();
 
     g_CreateCompositionSwapChainHookAttached = false;

--- a/dll/D3D11Capture.cpp
+++ b/dll/D3D11Capture.cpp
@@ -28,6 +28,21 @@ typedef HRESULT(STDMETHODCALLTYPE* CreateCompositionSwapChainFn)(
     IDXGIOutput* restrictToOutput,
     IDXGISwapChain1** swapChain);
 
+typedef HRESULT(STDMETHODCALLTYPE* CreateSwapChainFn)(
+    IDXGIFactory* factory,
+    IUnknown* device,
+    DXGI_SWAP_CHAIN_DESC* description,
+    IDXGISwapChain** swapChain);
+
+typedef HRESULT(STDMETHODCALLTYPE* CreateSwapChainForHwndFn)(
+    IDXGIFactory2* factory,
+    IUnknown* device,
+    HWND window,
+    const DXGI_SWAP_CHAIN_DESC1* description,
+    const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* fullscreenDescription,
+    IDXGIOutput* restrictToOutput,
+    IDXGISwapChain1** swapChain);
+
 typedef HRESULT(STDMETHODCALLTYPE* SwapChainPresentFn)(
     IDXGISwapChain* swapChain,
     UINT syncInterval,
@@ -62,13 +77,19 @@ static std::vector<MsRdpEx_D3D11CaptureSwapChain> g_SwapChains;
 
 static D3D11CreateDeviceFn Real_D3D11CreateDevice = D3D11CreateDevice;
 static CreateCompositionSwapChainFn Real_CreateCompositionSwapChain = NULL;
+static CreateSwapChainFn Real_CreateSwapChain = NULL;
+static CreateSwapChainForHwndFn Real_CreateSwapChainForHwnd = NULL;
 static SwapChainPresentFn Real_SwapChainPresent = NULL;
 static SwapChainReleaseFn Real_SwapChainRelease = NULL;
 
 static bool g_CreateCompositionSwapChainHookAttached = false;
+static bool g_CreateSwapChainHookAttached = false;
+static bool g_CreateSwapChainForHwndHookAttached = false;
 static bool g_SwapChainPresentHookAttached = false;
 static bool g_SwapChainReleaseHookAttached = false;
 static PVOID g_CreateCompositionSwapChainTarget = NULL;
+static PVOID g_CreateSwapChainTarget = NULL;
+static PVOID g_CreateSwapChainForHwndTarget = NULL;
 static PVOID g_SwapChainPresentTarget = NULL;
 static PVOID g_SwapChainReleaseTarget = NULL;
 static thread_local LONG g_D3D11CaptureDepth = 0;
@@ -77,6 +98,19 @@ static HRESULT STDMETHODCALLTYPE Hook_CreateCompositionSwapChain(
     IDXGIFactory2* factory,
     IUnknown* device,
     const DXGI_SWAP_CHAIN_DESC1* description,
+    IDXGIOutput* restrictToOutput,
+    IDXGISwapChain1** swapChain);
+static HRESULT STDMETHODCALLTYPE Hook_CreateSwapChain(
+    IDXGIFactory* factory,
+    IUnknown* device,
+    DXGI_SWAP_CHAIN_DESC* description,
+    IDXGISwapChain** swapChain);
+static HRESULT STDMETHODCALLTYPE Hook_CreateSwapChainForHwnd(
+    IDXGIFactory2* factory,
+    IUnknown* device,
+    HWND window,
+    const DXGI_SWAP_CHAIN_DESC1* description,
+    const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* fullscreenDescription,
     IDXGIOutput* restrictToOutput,
     IDXGISwapChain1** swapChain);
 
@@ -234,9 +268,33 @@ static bool MsRdpEx_D3D11Capture_AttachSwapChainHooks(IDXGISwapChain* swapChain)
     return true;
 }
 
+static bool MsRdpEx_D3D11Capture_AttachFactoryHook(
+    void** vtable,
+    size_t slot,
+    PVOID* realFunction,
+    PVOID hookFunction,
+    bool* attached,
+    PVOID* target)
+{
+    if (*attached)
+        return vtable[slot] == *target;
+
+    *realFunction = vtable[slot];
+    *target = *realFunction;
+    if (MsRdpEx_D3D11Capture_AttachDynamicHook(
+            realFunction, hookFunction, attached))
+    {
+        return true;
+    }
+
+    *realFunction = NULL;
+    *target = NULL;
+    return false;
+}
+
 static void MsRdpEx_D3D11Capture_TrackSwapChain(
     IUnknown* device,
-    IDXGISwapChain1* swapChain)
+    IDXGISwapChain* swapChain)
 {
     IMsRdpExInstance* instance = MsRdpEx_D3D11Capture_FindInstanceForDevice(device);
     if (!instance)
@@ -245,7 +303,7 @@ static void MsRdpEx_D3D11Capture_TrackSwapChain(
         if (instance)
         {
             MsRdpEx_D3D11Capture_DisableHardwareMode(
-                instance, "attribute composition swap chain to RDP device", E_FAIL);
+                instance, "attribute DXGI swap chain to RDP device", E_FAIL);
             instance->Release();
         }
         return;
@@ -258,7 +316,7 @@ static void MsRdpEx_D3D11Capture_TrackSwapChain(
     if (FAILED(hr))
     {
         MsRdpEx_D3D11Capture_DisableHardwareMode(
-            instance, "query composition swap-chain device", hr);
+            instance, "query DXGI swap-chain device", hr);
         instance->Release();
         return;
     }
@@ -267,7 +325,7 @@ static void MsRdpEx_D3D11Capture_TrackSwapChain(
     if (!context || !MsRdpEx_D3D11Capture_AttachSwapChainHooks(swapChain))
     {
         MsRdpEx_D3D11Capture_DisableHardwareMode(
-            instance, "hook RDP composition swap chain", E_FAIL);
+            instance, "hook RDP DXGI swap chain", E_FAIL);
         if (context)
             context->Release();
         d3dDevice->Release();
@@ -286,7 +344,7 @@ static void MsRdpEx_D3D11Capture_TrackSwapChain(
     ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
 
     MsRdpEx_LogPrint(DEBUG,
-        "D3D11 capture tracking RDP composition swap chain: %p", swapChain);
+        "D3D11 capture tracking RDP DXGI swap chain: %p", swapChain);
 
     if (!MsRdpEx_Instance_ArmHardwareCaptureWatchdog(instance))
     {
@@ -435,6 +493,39 @@ static HRESULT STDMETHODCALLTYPE Hook_CreateCompositionSwapChain(
     return hr;
 }
 
+static HRESULT STDMETHODCALLTYPE Hook_CreateSwapChain(
+    IDXGIFactory* factory,
+    IUnknown* device,
+    DXGI_SWAP_CHAIN_DESC* description,
+    IDXGISwapChain** swapChain)
+{
+    HRESULT hr = Real_CreateSwapChain(factory, device, description, swapChain);
+
+    if (SUCCEEDED(hr) && swapChain && *swapChain)
+        MsRdpEx_D3D11Capture_TrackSwapChain(device, *swapChain);
+
+    return hr;
+}
+
+static HRESULT STDMETHODCALLTYPE Hook_CreateSwapChainForHwnd(
+    IDXGIFactory2* factory,
+    IUnknown* device,
+    HWND window,
+    const DXGI_SWAP_CHAIN_DESC1* description,
+    const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* fullscreenDescription,
+    IDXGIOutput* restrictToOutput,
+    IDXGISwapChain1** swapChain)
+{
+    HRESULT hr = Real_CreateSwapChainForHwnd(
+        factory, device, window, description, fullscreenDescription,
+        restrictToOutput, swapChain);
+
+    if (SUCCEEDED(hr) && swapChain && *swapChain)
+        MsRdpEx_D3D11Capture_TrackSwapChain(device, *swapChain);
+
+    return hr;
+}
+
 static HRESULT STDMETHODCALLTYPE Hook_SwapChainPresent(
     IDXGISwapChain* swapChain,
     UINT syncInterval,
@@ -567,26 +658,28 @@ static void MsRdpEx_D3D11Capture_TrackDevice(ID3D11Device* device)
         void** vtable = *(void***)factory;
 
         AcquireSRWLockExclusive(&g_D3D11CaptureLock);
-        if (!g_CreateCompositionSwapChainHookAttached)
-        {
-            Real_CreateCompositionSwapChain = (CreateCompositionSwapChainFn)vtable[24];
-            g_CreateCompositionSwapChainTarget = (PVOID)Real_CreateCompositionSwapChain;
-            if (!MsRdpEx_D3D11Capture_AttachDynamicHook(
-                (PVOID*)&Real_CreateCompositionSwapChain,
-                (PVOID)Hook_CreateCompositionSwapChain,
-                &g_CreateCompositionSwapChainHookAttached))
-            {
-                Real_CreateCompositionSwapChain = NULL;
-                MsRdpEx_D3D11Capture_DisableHardwareMode(
-                    instance, "hook IDXGIFactory2::CreateSwapChainForComposition", E_FAIL);
-            }
-        }
-        else if (vtable[24] != g_CreateCompositionSwapChainTarget)
+        const bool compositionHooked = MsRdpEx_D3D11Capture_AttachFactoryHook(
+            vtable, 24, (PVOID*)&Real_CreateCompositionSwapChain,
+            (PVOID)Hook_CreateCompositionSwapChain,
+            &g_CreateCompositionSwapChainHookAttached,
+            &g_CreateCompositionSwapChainTarget);
+        const bool legacyHooked = MsRdpEx_D3D11Capture_AttachFactoryHook(
+            vtable, 10, (PVOID*)&Real_CreateSwapChain,
+            (PVOID)Hook_CreateSwapChain,
+            &g_CreateSwapChainHookAttached,
+            &g_CreateSwapChainTarget);
+        const bool hwndHooked = MsRdpEx_D3D11Capture_AttachFactoryHook(
+            vtable, 15, (PVOID*)&Real_CreateSwapChainForHwnd,
+            (PVOID)Hook_CreateSwapChainForHwnd,
+            &g_CreateSwapChainForHwndHookAttached,
+            &g_CreateSwapChainForHwndTarget);
+        ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
+
+        if (!compositionHooked && !legacyHooked && !hwndHooked)
         {
             MsRdpEx_D3D11Capture_DisableHardwareMode(
-                instance, "unsupported IDXGIFactory2 implementation", E_NOTIMPL);
+                instance, "hook RDP DXGI factory swap-chain methods", E_FAIL);
         }
-        ReleaseSRWLockExclusive(&g_D3D11CaptureLock);
     }
     else
     {
@@ -732,6 +825,8 @@ void MsRdpEx_D3D11Capture_DetachHooks()
 {
     MSRDPEX_DETOUR_DETACH(Real_D3D11CreateDevice, Hook_D3D11CreateDevice);
     MSRDPEX_DETOUR_DETACH(Real_CreateCompositionSwapChain, Hook_CreateCompositionSwapChain);
+    MSRDPEX_DETOUR_DETACH(Real_CreateSwapChain, Hook_CreateSwapChain);
+    MSRDPEX_DETOUR_DETACH(Real_CreateSwapChainForHwnd, Hook_CreateSwapChainForHwnd);
     MSRDPEX_DETOUR_DETACH(Real_SwapChainPresent, Hook_SwapChainPresent);
     MSRDPEX_DETOUR_DETACH(Real_SwapChainRelease, Hook_SwapChainRelease);
 }
@@ -759,12 +854,18 @@ void MsRdpEx_D3D11Capture_Shutdown()
     g_PendingInstances.clear();
 
     g_CreateCompositionSwapChainHookAttached = false;
+    g_CreateSwapChainHookAttached = false;
+    g_CreateSwapChainForHwndHookAttached = false;
     g_SwapChainPresentHookAttached = false;
     g_SwapChainReleaseHookAttached = false;
     g_CreateCompositionSwapChainTarget = NULL;
+    g_CreateSwapChainTarget = NULL;
+    g_CreateSwapChainForHwndTarget = NULL;
     g_SwapChainPresentTarget = NULL;
     g_SwapChainReleaseTarget = NULL;
     Real_CreateCompositionSwapChain = NULL;
+    Real_CreateSwapChain = NULL;
+    Real_CreateSwapChainForHwnd = NULL;
     Real_SwapChainPresent = NULL;
     Real_SwapChainRelease = NULL;
 

--- a/dll/D3D11Capture.h
+++ b/dll/D3D11Capture.h
@@ -1,0 +1,12 @@
+#ifndef MSRDPEX_D3D11_CAPTURE_H
+#define MSRDPEX_D3D11_CAPTURE_H
+
+#include "RdpInstanceInternal.h"
+
+void MsRdpEx_D3D11Capture_RegisterPendingInstance(IMsRdpExInstance* instance);
+void MsRdpEx_D3D11Capture_ReleaseInstance(IMsRdpExInstance* instance);
+void MsRdpEx_D3D11Capture_AttachHooks();
+void MsRdpEx_D3D11Capture_DetachHooks();
+void MsRdpEx_D3D11Capture_Shutdown();
+
+#endif /* MSRDPEX_D3D11_CAPTURE_H */

--- a/dll/MsRdpClient.cpp
+++ b/dll/MsRdpClient.cpp
@@ -1,5 +1,6 @@
 
 #include "MsRdpClient.h"
+#include "D3D11Capture.h"
 
 #include <MsRdpEx/MsRdpEx.h>
 
@@ -184,6 +185,8 @@ public:
     ~CMsRdpClient()
     {
         EndSspiSessionScope("destroy");
+        MsRdpEx_D3D11Capture_ReleaseInstance(
+            (IMsRdpExInstance*)m_pMsRdpExInstance);
 
         m_pUnknown->Release();
         if (m_pDispatch) m_pDispatch->Release();
@@ -511,8 +514,11 @@ public:
         BeginSspiSessionScope("connect");
         hr = m_pMsTscAx->raw_Connect();
 
-        if (FAILED(hr))
+        if (FAILED(hr)) {
+            MsRdpEx_D3D11Capture_ReleaseInstance(
+                (IMsRdpExInstance*)m_pMsRdpExInstance);
             EndSspiSessionScope("connect-failed");
+        }
 
         return hr;
     }
@@ -521,6 +527,8 @@ public:
         HRESULT hr;
         MsRdpEx_LogPrint(DEBUG, "CMsRdpClient::Disconnect");
 
+        MsRdpEx_D3D11Capture_ReleaseInstance(
+            (IMsRdpExInstance*)m_pMsRdpExInstance);
         hr = m_pMsTscAx->raw_Disconnect();
         EndSspiSessionScope("disconnect");
 
@@ -895,6 +903,18 @@ private:
     IClassFactory* m_pDelegate;
     ULONG m_refCount;
 };
+
+HRESULT MsRdpEx_CMsRdpClient_ReconnectInGdiMode(CMsRdpClient* rdpClient)
+{
+    if (!rdpClient)
+        return E_INVALIDARG;
+
+    HRESULT hr = rdpClient->raw_Disconnect();
+    if (FAILED(hr))
+        return hr;
+
+    return rdpClient->raw_Connect();
+}
 
 void* CDECL MsRdpEx_CClassFactory_New(REFCLSID rclsid, IClassFactory* pDelegate)
 {

--- a/dll/MsRdpClient.h
+++ b/dll/MsRdpClient.h
@@ -13,6 +13,9 @@ void* MsRdpEx_CClassFactory_New(REFCLSID rclsid, IClassFactory* pDelegate);
 
 #ifdef __cplusplus
 }
+
+class CMsRdpClient;
+HRESULT MsRdpEx_CMsRdpClient_ReconnectInGdiMode(CMsRdpClient* rdpClient);
 #endif
 
 #endif /* MSRDPEX_CLIENT_H */

--- a/dll/OutputMirror.c
+++ b/dll/OutputMirror.c
@@ -179,9 +179,26 @@ bool MsRdpEx_OutputMirror_GetShadowBitmap(MsRdpEx_OutputMirror* ctx,
 bool MsRdpEx_OutputMirror_Init(MsRdpEx_OutputMirror* ctx)
 {
 	ctx->hShadowDC = CreateCompatibleDC(ctx->hSourceDC);
+	if (!ctx->hShadowDC)
+		return false;
+
 	ctx->hShadowBitmap = MsRdpEx_CreateDIBSection(ctx->hSourceDC,
 		ctx->bitmapWidth, ctx->bitmapHeight, ctx->bitsPerPixel, &ctx->bitmapData);
+	if (!ctx->hShadowBitmap) {
+		DeleteDC(ctx->hShadowDC);
+		ctx->hShadowDC = NULL;
+		return false;
+	}
+
 	ctx->hShadowObject = SelectObject(ctx->hShadowDC, ctx->hShadowBitmap);
+	if (!ctx->hShadowObject || ctx->hShadowObject == HGDI_ERROR) {
+		DeleteObject(ctx->hShadowBitmap);
+		DeleteDC(ctx->hShadowDC);
+		ctx->hShadowBitmap = NULL;
+		ctx->hShadowDC = NULL;
+		ctx->bitmapData = NULL;
+		return false;
+	}
 
 	ctx->captureBaseTime = GetTickCount64();
 
@@ -260,6 +277,7 @@ bool MsRdpEx_OutputMirror_Uninit(MsRdpEx_OutputMirror* ctx)
 		DeleteObject(ctx->hShadowBitmap);
 		ctx->hShadowObject = NULL;
 		ctx->hShadowBitmap = NULL;
+		ctx->bitmapData = NULL;
 	}
 
 	if (ctx->hShadowDC)

--- a/dll/OutputMirrorCapture.cpp
+++ b/dll/OutputMirrorCapture.cpp
@@ -1,0 +1,125 @@
+#include "MsRdpEx.h"
+#include "OutputMirrorCapture.h"
+
+static SRWLOCK g_OutputMirrorCreationLock = SRWLOCK_INIT;
+
+MsRdpEx_OutputMirror* MsRdpEx_OutputMirror_GetOrCreate(
+    IMsRdpExInstance* instance,
+    CMsRdpExtendedSettings* extendedSettings)
+{
+    MsRdpEx_OutputMirror* outputMirror = NULL;
+
+    if (FAILED(instance->GetOutputMirrorObject((LPVOID*)&outputMirror)) || outputMirror)
+        return outputMirror;
+
+    AcquireSRWLockExclusive(&g_OutputMirrorCreationLock);
+
+    if (FAILED(instance->GetOutputMirrorObject((LPVOID*)&outputMirror)) || outputMirror)
+    {
+        ReleaseSRWLockExclusive(&g_OutputMirrorCreationLock);
+        return outputMirror;
+    }
+
+    outputMirror = MsRdpEx_OutputMirror_New();
+    if (!outputMirror) {
+        ReleaseSRWLockExclusive(&g_OutputMirrorCreationLock);
+        return NULL;
+    }
+
+    MsRdpEx_OutputMirror_SetDumpBitmapUpdates(
+        outputMirror, extendedSettings->GetDumpBitmapUpdates());
+    MsRdpEx_OutputMirror_SetVideoRecordingEnabled(
+        outputMirror, extendedSettings->GetVideoRecordingEnabled());
+    MsRdpEx_OutputMirror_SetVideoQualityLevel(
+        outputMirror, extendedSettings->GetVideoRecordingQuality());
+    MsRdpEx_OutputMirror_SetVideoFrameRate(
+        outputMirror, extendedSettings->GetVideoRecordingFrameRate());
+
+    char* recordingPath = extendedSettings->GetRecordingPath();
+    if (recordingPath)
+    {
+        MsRdpEx_OutputMirror_SetRecordingPath(outputMirror, recordingPath);
+        free(recordingPath);
+    }
+
+    char* recordingPipeName = extendedSettings->GetRecordingPipeName();
+    if (recordingPipeName)
+    {
+        MsRdpEx_OutputMirror_SetRecordingPipeName(outputMirror, recordingPipeName);
+        free(recordingPipeName);
+    }
+
+    const char* sessionId = extendedSettings->GetRecordingSessionId();
+    if (!sessionId)
+        sessionId = extendedSettings->GetSessionId();
+    MsRdpEx_OutputMirror_SetSessionId(outputMirror, sessionId);
+
+    instance->SetOutputMirrorObject((LPVOID)outputMirror);
+    ReleaseSRWLockExclusive(&g_OutputMirrorCreationLock);
+    return outputMirror;
+}
+
+bool MsRdpEx_OutputMirror_CapturePixels(
+    IMsRdpExInstance* instance,
+    const uint8_t* pixels,
+    uint32_t width,
+    uint32_t height,
+    uint32_t sourceStride)
+{
+    CMsRdpExtendedSettings* extendedSettings = NULL;
+    MsRdpEx_OutputMirror* outputMirror = NULL;
+    uint32_t frameWidth = 0;
+    uint32_t frameHeight = 0;
+    uint32_t frameStride = 0;
+    uint8_t* framePixels = NULL;
+    HDC frameDC = NULL;
+    HBITMAP frameBitmap = NULL;
+
+    if (!instance || !pixels || !width || !height || sourceStride < (width * 4))
+        return false;
+
+    if (!instance->GetExtendedSettings(&extendedSettings) ||
+        !extendedSettings->GetOutputMirrorEnabled())
+    {
+        return false;
+    }
+
+    outputMirror = MsRdpEx_OutputMirror_GetOrCreate(instance, extendedSettings);
+    if (!outputMirror)
+        return false;
+
+    MsRdpEx_OutputMirror_Lock(outputMirror);
+    MsRdpEx_OutputMirror_GetFrameSize(outputMirror, &frameWidth, &frameHeight);
+
+    if (frameWidth != width || frameHeight != height)
+    {
+        MsRdpEx_OutputMirror_Uninit(outputMirror);
+        MsRdpEx_OutputMirror_SetSourceDC(outputMirror, NULL);
+        MsRdpEx_OutputMirror_SetFrameSize(outputMirror, width, height);
+        if (!MsRdpEx_OutputMirror_Init(outputMirror))
+        {
+            MsRdpEx_OutputMirror_Unlock(outputMirror);
+            return false;
+        }
+    }
+
+    MsRdpEx_OutputMirror_GetShadowBitmap(
+        outputMirror, &frameDC, &frameBitmap, &framePixels,
+        &frameWidth, &frameHeight, &frameStride);
+
+    if (!frameDC || !frameBitmap || !framePixels || frameStride < (width * 4))
+    {
+        MsRdpEx_OutputMirror_Unlock(outputMirror);
+        return false;
+    }
+
+    for (uint32_t y = 0; y < height; y++)
+    {
+        memcpy(framePixels + (size_t)y * frameStride,
+            pixels + (size_t)y * sourceStride, (size_t)width * 4);
+    }
+
+    instance->DumpFrameWithCursor();
+    MsRdpEx_OutputMirror_Unlock(outputMirror);
+    return true;
+}

--- a/dll/OutputMirrorCapture.cpp
+++ b/dll/OutputMirrorCapture.cpp
@@ -98,6 +98,7 @@ bool MsRdpEx_OutputMirror_CapturePixels(
         MsRdpEx_OutputMirror_SetFrameSize(outputMirror, width, height);
         if (!MsRdpEx_OutputMirror_Init(outputMirror))
         {
+            MsRdpEx_OutputMirror_SetFrameSize(outputMirror, 0, 0);
             MsRdpEx_OutputMirror_Unlock(outputMirror);
             return false;
         }

--- a/dll/OutputMirrorCapture.h
+++ b/dll/OutputMirrorCapture.h
@@ -1,0 +1,20 @@
+#ifndef MSRDPEX_OUTPUT_MIRROR_CAPTURE_H
+#define MSRDPEX_OUTPUT_MIRROR_CAPTURE_H
+
+#include "RdpInstanceInternal.h"
+
+#include <MsRdpEx/OutputMirror.h>
+#include <MsRdpEx/RdpSettings.h>
+
+MsRdpEx_OutputMirror* MsRdpEx_OutputMirror_GetOrCreate(
+    IMsRdpExInstance* instance,
+    CMsRdpExtendedSettings* extendedSettings);
+
+bool MsRdpEx_OutputMirror_CapturePixels(
+    IMsRdpExInstance* instance,
+    const uint8_t* pixels,
+    uint32_t width,
+    uint32_t height,
+    uint32_t sourceStride);
+
+#endif /* MSRDPEX_OUTPUT_MIRROR_CAPTURE_H */

--- a/dll/RdpInstance.cpp
+++ b/dll/RdpInstance.cpp
@@ -10,6 +10,7 @@
 #include "TSObjects.h"
 #include "ComHelpers.h"
 #include "CursorOverlay.h"
+#include "MsRdpClient.h"
 #include "RdpInstanceInternal.h"
 
 extern "C" const GUID IID_IMsRdpExInstance;
@@ -31,6 +32,9 @@ public:
 
     ~CMsRdpExInstance()
     {
+        if (m_hOutputPresenterWnd)
+            KillTimer(m_hOutputPresenterWnd, MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId());
+
         if (m_CursorOverlay) {
             MsRdpEx_CursorOverlay_Free(m_CursorOverlay);
             m_CursorOverlay = NULL;
@@ -225,6 +229,20 @@ public:
     HRESULT STDMETHODCALLTYPE AttachOutputWindow(HWND hOutputWnd, void* pUserData)
     {
         m_hOutputPresenterWnd = hOutputWnd;
+        if (m_GdiReconnectPending != 0 &&
+            !PostMessage(hOutputWnd, MsRdpEx_Instance_GetGdiReconnectMessage(), 0, 0))
+        {
+            InterlockedExchange(&m_GdiReconnectPending, 0);
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        if (m_HardwareCaptureWatchdogPending != 0 &&
+            !SetTimer(hOutputWnd, MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId(), 5000, NULL))
+        {
+            InterlockedExchange(&m_HardwareCaptureWatchdogPending, 0);
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
         return S_OK;
     }
 
@@ -355,6 +373,132 @@ public:
             MsRdpEx_OutputMirror_DumpFrame(outputMirror);
     }
 
+    bool RequestGdiReconnect()
+    {
+        if (InterlockedCompareExchange(&m_GdiReconnectPending, 1, 0) != 0)
+            return true;
+
+        const UINT message = MsRdpEx_Instance_GetGdiReconnectMessage();
+        if (!message)
+        {
+            InterlockedExchange(&m_GdiReconnectPending, 0);
+            return false;
+        }
+
+        if (!m_hOutputPresenterWnd)
+            return true;
+
+        if (!PostMessage(m_hOutputPresenterWnd, message, 0, 0))
+        {
+            InterlockedExchange(&m_GdiReconnectPending, 0);
+            return false;
+        }
+
+        return true;
+    }
+
+    bool ArmHardwareCaptureWatchdog()
+    {
+        InterlockedExchange(&m_HardwareCaptureFrameReceived, 0);
+        InterlockedExchange(&m_GdiReconnectAttempts, 0);
+
+        if (InterlockedCompareExchange(&m_HardwareCaptureWatchdogPending, 1, 0) != 0)
+            return true;
+
+        if (!m_hOutputPresenterWnd)
+            return true;
+
+        if (!SetTimer(m_hOutputPresenterWnd,
+                MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId(), 5000, NULL))
+        {
+            InterlockedExchange(&m_HardwareCaptureWatchdogPending, 0);
+            return false;
+        }
+
+        return true;
+    }
+
+    void HandleHardwareCaptureWatchdog()
+    {
+        if (m_hOutputPresenterWnd)
+            KillTimer(m_hOutputPresenterWnd, MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId());
+
+        if (InterlockedExchange(&m_HardwareCaptureWatchdogPending, 0) == 0 ||
+            InterlockedCompareExchange(&m_HardwareCaptureFrameReceived, 0, 0) != 0)
+        {
+            return;
+        }
+
+        MsRdpEx_LogPrint(ERROR,
+            "D3D11 capture did not produce a frame within the watchdog interval");
+        RequestGdiReconnect();
+    }
+
+    void DisarmHardwareCaptureWatchdog()
+    {
+        if (m_hOutputPresenterWnd)
+            KillTimer(m_hOutputPresenterWnd,
+                MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId());
+
+        InterlockedExchange(&m_HardwareCaptureWatchdogPending, 0);
+        InterlockedExchange(&m_HardwareCaptureFrameReceived, 0);
+        InterlockedExchange(&m_GdiReconnectPending, 0);
+    }
+
+    void NotifyOutputFrame()
+    {
+        InterlockedExchange(&m_HardwareCaptureFrameReceived, 1);
+
+        if (InterlockedExchange(&m_HardwareCaptureWatchdogPending, 0) != 0 &&
+            m_hOutputPresenterWnd)
+        {
+            KillTimer(m_hOutputPresenterWnd,
+                MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId());
+        }
+    }
+
+    void ReconnectUsingGdi()
+    {
+        if (InterlockedExchange(&m_GdiReconnectPending, 0) == 0 ||
+            !m_pMsRdpClient || !m_pMsRdpExtendedSettings)
+        {
+            return;
+        }
+
+        if (InterlockedCompareExchange(&m_GdiReconnectAttempts, 1, 0) != 0)
+        {
+            MsRdpEx_LogPrint(ERROR,
+                "Skipping repeated DirectX capture fallback reconnect");
+            return;
+        }
+
+        VARIANT enableHardwareMode;
+        bstr_t enableHardwareModeName =
+            _com_util::ConvertStringToBSTR("EnableHardwareMode");
+        VariantInit(&enableHardwareMode);
+        enableHardwareMode.vt = VT_BOOL;
+        enableHardwareMode.boolVal = VARIANT_FALSE;
+        HRESULT hr = m_pMsRdpExtendedSettings->put_Property(
+            enableHardwareModeName, &enableHardwareMode);
+        VariantClear(&enableHardwareMode);
+
+        if (FAILED(hr))
+        {
+            MsRdpEx_LogPrint(ERROR,
+                "Could not disable hardware presentation for DirectX capture fallback: 0x%08X",
+                hr);
+            return;
+        }
+
+        hr = MsRdpEx_CMsRdpClient_ReconnectInGdiMode(m_pMsRdpClient);
+        if (FAILED(hr))
+        {
+            MsRdpEx_LogPrint(ERROR,
+                "Could not reconnect with GDI presentation after DirectX capture failure: 0x%08X",
+                hr);
+        }
+    }
+
 private:
     MsRdpEx_OutputMirror* GetOutputMirror()
     {
@@ -411,12 +555,62 @@ public:
     int32_t m_LastMousePosX = 0;
     int32_t m_LastMousePosY = 0;
     IUnknown* m_WTSPlugin = NULL;
+    LONG m_GdiReconnectPending = 0;
+    LONG m_GdiReconnectAttempts = 0;
+    LONG m_HardwareCaptureFrameReceived = 0;
+    LONG m_HardwareCaptureWatchdogPending = 0;
 };
 
 CMsRdpExInstance* CMsRdpExInstance_New(CMsRdpClient* pMsRdpClient)
 {
     CMsRdpExInstance* instance = new CMsRdpExInstance(pMsRdpClient);
     return instance;
+}
+
+UINT MsRdpEx_Instance_GetGdiReconnectMessage()
+{
+    static const UINT message = RegisterWindowMessageW(
+        L"MsRdpEx.GdiReconnect.7E14CFC3-4C24-466B-AC8A-7C1A45D4F5AB");
+    return message;
+}
+
+UINT_PTR MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId()
+{
+    return 0x7E14;
+}
+
+bool MsRdpEx_Instance_RequestGdiReconnect(IMsRdpExInstance* instance)
+{
+    return instance && ((CMsRdpExInstance*)instance)->RequestGdiReconnect();
+}
+
+bool MsRdpEx_Instance_ArmHardwareCaptureWatchdog(IMsRdpExInstance* instance)
+{
+    return instance && ((CMsRdpExInstance*)instance)->ArmHardwareCaptureWatchdog();
+}
+
+void MsRdpEx_Instance_DisarmHardwareCaptureWatchdog(IMsRdpExInstance* instance)
+{
+    if (instance)
+        ((CMsRdpExInstance*)instance)->DisarmHardwareCaptureWatchdog();
+}
+
+void MsRdpEx_Instance_HandleHardwareCaptureWatchdog(IMsRdpExInstance* instance)
+{
+    if (instance)
+        ((CMsRdpExInstance*)instance)->HandleHardwareCaptureWatchdog();
+}
+
+void MsRdpEx_Instance_NotifyOutputFrame(IMsRdpExInstance* instance)
+{
+    if (instance)
+        ((CMsRdpExInstance*)instance)->NotifyOutputFrame();
+}
+
+void MsRdpEx_Instance_ReconnectUsingGdi(IMsRdpExInstance* instance)
+{
+    if (instance)
+        ((CMsRdpExInstance*)instance)->ReconnectUsingGdi();
 }
 
 struct _MsRdpEx_OutputMirrorCapture

--- a/dll/RdpInstanceInternal.h
+++ b/dll/RdpInstanceInternal.h
@@ -5,5 +5,13 @@
 
 IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByOutputPresenterHwnd(HWND hWnd);
 IMsRdpExInstance* MsRdpEx_InstanceManager_AcquireByInputCaptureHwnd(HWND hWnd);
+UINT MsRdpEx_Instance_GetGdiReconnectMessage();
+UINT_PTR MsRdpEx_Instance_GetHardwareCaptureWatchdogTimerId();
+bool MsRdpEx_Instance_RequestGdiReconnect(IMsRdpExInstance* instance);
+void MsRdpEx_Instance_ReconnectUsingGdi(IMsRdpExInstance* instance);
+bool MsRdpEx_Instance_ArmHardwareCaptureWatchdog(IMsRdpExInstance* instance);
+void MsRdpEx_Instance_DisarmHardwareCaptureWatchdog(IMsRdpExInstance* instance);
+void MsRdpEx_Instance_HandleHardwareCaptureWatchdog(IMsRdpExInstance* instance);
+void MsRdpEx_Instance_NotifyOutputFrame(IMsRdpExInstance* instance);
 
 #endif /* MSRDPEX_RDP_INSTANCE_INTERNAL_H */

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -1004,6 +1004,18 @@ HRESULT __stdcall CMsRdpExtendedSettings::put_Property(BSTR bstrPropertyName, VA
         }
 
         hr = m_pMsRdpExtendedSettings->put_Property(bstrPropertyName, pValue);
+
+        if (SUCCEEDED(hr) &&
+            MsRdpEx_StringEquals(propName, "EnableHardwareMode") &&
+            pValue->vt == VT_BOOL &&
+            pValue->boolVal == VARIANT_TRUE &&
+            m_OutputMirrorEnabled)
+        {
+            IMsRdpExInstance* instance = (IMsRdpExInstance*)
+                MsRdpEx_InstanceManager_FindBySessionId(&m_sessionId);
+            if (instance)
+                MsRdpEx_D3D11Capture_RegisterPendingInstance(instance);
+        }
     }
 
 end:

--- a/dll/RdpSettings.cpp
+++ b/dll/RdpSettings.cpp
@@ -14,6 +14,7 @@
 #include <wincred.h>
 
 #include "MsRdpEx.h"
+#include "D3D11Capture.h"
 #include "TSObjects.h"
 #include "ComHelpers.h"
 
@@ -1706,8 +1707,16 @@ HRESULT CMsRdpExtendedSettings::PrepareVideoRecorder()
     if (outputMirrorEnabled) {
         VARIANT enableHardwareMode;
         bstr_t enableHardwareModeName = _com_util::ConvertStringToBSTR("EnableHardwareMode");
-        VariantInitBool(&enableHardwareMode, false);
-        this->put_Property(enableHardwareModeName, &enableHardwareMode);
+        VariantInit(&enableHardwareMode);
+
+        if (SUCCEEDED(this->get_Property(enableHardwareModeName, &enableHardwareMode)) &&
+            enableHardwareMode.vt == VT_BOOL &&
+            enableHardwareMode.boolVal == VARIANT_TRUE)
+        {
+            MsRdpEx_D3D11Capture_RegisterPendingInstance(instance);
+        }
+
+        VariantClear(&enableHardwareMode);
     }
 
     return hr;

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -64,7 +64,6 @@ internal sealed class RdpActiveXSession : IDisposable
     private static int oleSessionCount;
     private static RdpOleHostAttach? rdpOleHostAttach;
     private static RdpOleHostSetBounds? rdpOleHostSetBounds;
-    private static RdpOleHostSetFrameActive? rdpOleHostSetFrameActive;
     private static RdpOleHostSetFrameWindow? rdpOleHostSetFrameWindow;
     private static RdpOleHostTranslateAccelerator? rdpOleHostTranslateAccelerator;
     private static RdpOleHostRelease? rdpOleHostRelease;
@@ -304,21 +303,6 @@ internal sealed class RdpActiveXSession : IDisposable
             PublishStatus("Disconnecting...");
             client.Disconnect();
         }
-    }
-
-    /// <summary>
-    /// Forwards top-level window activation to the OLE frame
-    /// (OnFrameWindowActivate) without touching the UI-active state: Avalonia
-    /// retains logical focus while its window is deactivated.
-    /// </summary>
-    public void SetFrameActive(bool active)
-    {
-        if (disposed || oleHost == 0 || rdpOleHostSetFrameActive is null)
-            return;
-
-        int hr = rdpOleHostSetFrameActive(oleHost, active ? 1 : 0);
-        if (hr < 0)
-            PublishStatus($"RDP OLE frame activation failed: 0x{hr:X8}");
     }
 
     /// <summary>
@@ -640,13 +624,6 @@ internal sealed class RdpActiveXSession : IDisposable
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_TranslateAccelerator"));
         rdpOleHostRelease ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostRelease>(
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_Release"));
-
-        if (rdpOleHostSetFrameActive is null &&
-            NativeLibrary.TryGetExport(library, "MsRdpEx_RdpOleHost_SetFrameActive", out nint setFrameActive))
-        {
-            rdpOleHostSetFrameActive =
-                Marshal.GetDelegateForFunctionPointer<RdpOleHostSetFrameActive>(setFrameActive);
-        }
 
         if (rdpOleHostSetFrameWindow is null &&
             NativeLibrary.TryGetExport(library, "MsRdpEx_RdpOleHost_SetFrameWindow", out nint setFrameWindow))
@@ -1131,9 +1108,6 @@ internal sealed class RdpActiveXSession : IDisposable
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int RdpOleHostSetBounds(nint host, ref NativeRect bounds);
-
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    private delegate int RdpOleHostSetFrameActive(nint host, int active);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int RdpOleHostSetFrameWindow(nint host, nint frameWindow);

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -634,7 +634,7 @@ internal sealed class RdpActiveXSession : IDisposable
         IMsRdpExtendedSettings extendedSettings = ProxyObject.Pack<IMsRdpExtendedSettings>(rawClient)
             ?? throw new InvalidOperationException("The RDP control does not expose MsRdpEx extended settings.");
         extendedSettings.SetProperty(new BinaryString("OutputMirrorEnabled"), true);
-        extendedSettings.SetProperty(new BinaryString("EnableHardwareMode"), false);
+        extendedSettings.SetProperty(new BinaryString("EnableHardwareMode"), true);
         instance?.SetOutputMirrorEnabled(true);
     }
 

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpActiveXSession.cs
@@ -64,7 +64,6 @@ internal sealed class RdpActiveXSession : IDisposable
     private static int oleSessionCount;
     private static RdpOleHostAttach? rdpOleHostAttach;
     private static RdpOleHostSetBounds? rdpOleHostSetBounds;
-    private static RdpOleHostSetActive? rdpOleHostSetActive;
     private static RdpOleHostSetFrameActive? rdpOleHostSetFrameActive;
     private static RdpOleHostSetFrameWindow? rdpOleHostSetFrameWindow;
     private static RdpOleHostTranslateAccelerator? rdpOleHostTranslateAccelerator;
@@ -84,7 +83,6 @@ internal sealed class RdpActiveXSession : IDisposable
     private bool oleScopeEntered;
     private bool oleInitializedByUs;
     private bool oleUninitializePending;
-    private bool oleUiActive;
     private bool disposed;
     private bool remoteMouseDragActive;
     private int sessionDesktopWidth;
@@ -306,31 +304,6 @@ internal sealed class RdpActiveXSession : IDisposable
             PublishStatus("Disconnecting...");
             client.Disconnect();
         }
-    }
-
-    /// <summary>
-    /// Pushes focus-driven OLE activation state (OnFrameWindowActivate /
-    /// OnDocWindowActivate) from view focus changes. The control is not
-    /// UI-activated with OLEIVERB_UIACTIVATE: in this hosting model that makes
-    /// mstscax grab keyboard focus and change the active window, hijacking
-    /// input from the Avalonia surface. Redundant transitions are suppressed
-    /// both here and in the native host.
-    /// </summary>
-    public void SetUiActive(bool active)
-    {
-        if (disposed || oleHost == 0 || rdpOleHostSetActive is null || oleUiActive == active)
-            return;
-
-        // Commit the managed state only after the native transition succeeds
-        // so a failed UIACTIVATE can be retried on the next focus change.
-        int hr = rdpOleHostSetActive(oleHost, active ? 1 : 0);
-        if (hr < 0)
-        {
-            PublishStatus($"RDP OLE activation failed: 0x{hr:X8}");
-            return;
-        }
-
-        oleUiActive = active;
     }
 
     /// <summary>
@@ -663,8 +636,6 @@ internal sealed class RdpActiveXSession : IDisposable
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_Attach"));
         rdpOleHostSetBounds ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostSetBounds>(
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_SetBounds"));
-        rdpOleHostSetActive ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostSetActive>(
-            NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_SetActive"));
         rdpOleHostTranslateAccelerator ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostTranslateAccelerator>(
             NativeLibrary.GetExport(library, "MsRdpEx_RdpOleHost_TranslateAccelerator"));
         rdpOleHostRelease ??= Marshal.GetDelegateForFunctionPointer<RdpOleHostRelease>(
@@ -997,8 +968,6 @@ internal sealed class RdpActiveXSession : IDisposable
             rdpOleHostRelease?.Invoke(host);
         }
 
-        oleUiActive = false;
-
         // Release the managed COM wrapper deterministically where the runtime
         // supports it. The generated interop wraps the control through
         // ComInterfaceMarshaller (StrategyBasedComWrappers), which offers no
@@ -1162,9 +1131,6 @@ internal sealed class RdpActiveXSession : IDisposable
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int RdpOleHostSetBounds(nint host, ref NativeRect bounds);
-
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    private delegate int RdpOleHostSetActive(nint host, int active);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int RdpOleHostSetFrameActive(nint host, int active);

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -359,10 +359,6 @@ public class RdpClientView : UserControl, IDisposable
         {
             Initialize();
             UpdateOleFrameState();
-            // The hidden ActiveX input HWND can own foreground while the view is
-            // first displayed. Enable its background-input path before the first
-            // pointer event so the initial click can be forwarded to the session.
-            session?.SetUiActive(true);
             StartCaptureWorker();
         }
         catch (Exception exception)
@@ -387,7 +383,6 @@ public class RdpClientView : UserControl, IDisposable
         ReleaseMouseButtons();
         // Deactivate the frame before dropping its window so the control is
         // not left believing a detached frame is still active.
-        session?.SetUiActive(false);
         session?.SetFrameActive(false);
         session?.SetFrameWindow(0);
         topLevel = null;
@@ -397,7 +392,9 @@ public class RdpClientView : UserControl, IDisposable
 
     // Reports the real top-level window to the OLE host so control-owned
     // dialogs (certificate warnings, credential prompts) are parented to a
-    // visible window, and pushes the current frame/focus activation state.
+    // visible window, and forwards only frame activation. Document activation
+    // would focus the hidden ActiveX input HWND and steal physical input from
+    // the Avalonia surface.
     private void UpdateOleFrameState()
     {
         if (session is null)
@@ -409,7 +406,6 @@ public class RdpClientView : UserControl, IDisposable
         if (topLevel is Window window)
             session.SetFrameActive(window.IsActive);
 
-        session.SetUiActive(IsKeyboardFocusWithin);
     }
 
     /// <summary>
@@ -492,7 +488,6 @@ public class RdpClientView : UserControl, IDisposable
     {
         base.OnPointerPressed(e);
         Focus();
-        session?.SetUiActive(true);
 
         if (IsViewOnly)
             return;
@@ -691,7 +686,6 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnControlLostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
-        session?.SetUiActive(false);
         UninstallKeyboardHook();
         ReleaseForwardedKeys();
         if (!ContinuePhysicalMouseDrag())
@@ -700,14 +694,12 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnControlGotFocus(object? sender, FocusChangedEventArgs e)
     {
-        session?.SetUiActive(true);
         InstallKeyboardHook();
     }
 
     private void OnWindowActivated(object? sender, EventArgs e)
     {
         session?.SetFrameActive(true);
-        session?.SetUiActive(IsKeyboardFocusWithin);
         if (IsKeyboardFocusWithin)
             InstallKeyboardHook();
     }
@@ -719,7 +711,6 @@ public class RdpClientView : UserControl, IDisposable
         // leaving the hook installed during that interval can swallow input
         // intended for another local application.
         UninstallKeyboardHook();
-        session?.SetUiActive(false);
         session?.SetFrameActive(false);
 
         // Avalonia retains logical keyboard focus while its window is

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -83,6 +83,7 @@ public class RdpClientView : UserControl, IDisposable
     private PixelSize viewportPixelSize;
     private uint staFrameVersion;
     private bool staHasFrameVersion;
+    private bool remoteInputActive;
     private bool disposed;
 
     public RdpClientView()
@@ -387,9 +388,6 @@ public class RdpClientView : UserControl, IDisposable
         resizeTimer.Stop();
         ReleaseForwardedKeys();
         ReleaseMouseButtons();
-        // Deactivate the frame before dropping its window so the control is
-        // not left believing a detached frame is still active.
-        session?.SetFrameActive(false);
         session?.SetFrameWindow(0);
         topLevel = null;
 
@@ -398,9 +396,9 @@ public class RdpClientView : UserControl, IDisposable
 
     // Reports the real top-level window to the OLE host so control-owned
     // dialogs (certificate warnings, credential prompts) are parented to a
-    // visible window, and forwards only frame activation. Document activation
-    // would focus the hidden ActiveX input HWND and steal physical input from
-    // the Avalonia surface.
+    // visible window. Activation notifications are intentionally omitted:
+    // mstscax transfers foreground to its hidden input HWND in response to
+    // either frame or document activation.
     private void UpdateOleFrameState()
     {
         if (session is null)
@@ -408,9 +406,6 @@ public class RdpClientView : UserControl, IDisposable
 
         if (topLevel?.TryGetPlatformHandle() is { } platformHandle)
             session.SetFrameWindow(platformHandle.Handle);
-
-        if (topLevel is Window window)
-            session.SetFrameActive(window.IsActive);
 
     }
 
@@ -493,7 +488,6 @@ public class RdpClientView : UserControl, IDisposable
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
-        Focus();
 
         if (IsViewOnly)
             return;
@@ -501,6 +495,7 @@ public class RdpClientView : UserControl, IDisposable
         if (!TryMapToRemote(e.GetPosition(this), out int x, out int y))
             return;
 
+        remoteInputActive = true;
         PointerUpdateKind kind = e.GetCurrentPoint(this).Properties.PointerUpdateKind;
         uint message;
 
@@ -692,6 +687,7 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnControlLostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
+        remoteInputActive = false;
         UninstallKeyboardHook();
         ReleaseForwardedKeys();
         if (!ContinuePhysicalMouseDrag())
@@ -705,7 +701,6 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnWindowActivated(object? sender, EventArgs e)
     {
-        session?.SetFrameActive(true);
         InstallKeyboardHook();
     }
 
@@ -716,7 +711,7 @@ public class RdpClientView : UserControl, IDisposable
         // leaving the hook installed during that interval can swallow input
         // intended for another local application.
         UninstallKeyboardHook();
-        session?.SetFrameActive(false);
+        remoteInputActive = false;
 
         // Avalonia retains logical keyboard focus while its window is
         // deactivated, so LostFocus never fires. Release forwarded input here
@@ -768,7 +763,7 @@ public class RdpClientView : UserControl, IDisposable
         if (code < 0 || keyboardHook == 0 ||
             !ShouldForwardKeys(
                 IsViewOnly,
-                IsKeyboardFocusWithin,
+                IsKeyboardFocusWithin || remoteInputActive,
                 topLevel is not Window window || window.IsActive,
                 session?.IsConnectionActive == true,
                 IsTopLevelForegroundWindow()))
@@ -889,7 +884,7 @@ public class RdpClientView : UserControl, IDisposable
             return;
         }
 
-        Focus();
+        remoteInputActive = true;
         await Task.Delay(200);
         SendPasteShortcut();
         e.DragEffects = DragDropEffects.Copy;
@@ -1454,6 +1449,7 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnSessionFocusReleased(object? sender, RdpFocusReleasedEventArgs e)
     {
+        remoteInputActive = false;
         ReleaseForwardedKeys();
         FocusReleased?.Invoke(this, e);
     }

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -383,6 +383,7 @@ public class RdpClientView : UserControl, IDisposable
         ReleaseMouseButtons();
         // Deactivate the frame before dropping its window so the control is
         // not left believing a detached frame is still active.
+        session?.SetUiActive(false);
         session?.SetFrameActive(false);
         session?.SetFrameWindow(0);
         topLevel = null;
@@ -403,6 +404,8 @@ public class RdpClientView : UserControl, IDisposable
 
         if (topLevel is Window window)
             session.SetFrameActive(window.IsActive);
+
+        session.SetUiActive(IsKeyboardFocusWithin);
     }
 
     /// <summary>
@@ -485,6 +488,7 @@ public class RdpClientView : UserControl, IDisposable
     {
         base.OnPointerPressed(e);
         Focus();
+        session?.SetUiActive(true);
 
         if (IsViewOnly)
             return;
@@ -683,6 +687,7 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnControlLostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
+        session?.SetUiActive(false);
         UninstallKeyboardHook();
         ReleaseForwardedKeys();
         if (!ContinuePhysicalMouseDrag())
@@ -691,12 +696,14 @@ public class RdpClientView : UserControl, IDisposable
 
     private void OnControlGotFocus(object? sender, FocusChangedEventArgs e)
     {
+        session?.SetUiActive(true);
         InstallKeyboardHook();
     }
 
     private void OnWindowActivated(object? sender, EventArgs e)
     {
         session?.SetFrameActive(true);
+        session?.SetUiActive(IsKeyboardFocusWithin);
         if (IsKeyboardFocusWithin)
             InstallKeyboardHook();
     }
@@ -708,6 +715,7 @@ public class RdpClientView : UserControl, IDisposable
         // leaving the hook installed during that interval can swallow input
         // intended for another local application.
         UninstallKeyboardHook();
+        session?.SetUiActive(false);
         session?.SetFrameActive(false);
 
         // Avalonia retains logical keyboard focus while its window is

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -359,6 +359,10 @@ public class RdpClientView : UserControl, IDisposable
         {
             Initialize();
             UpdateOleFrameState();
+            // The hidden ActiveX input HWND can own foreground while the view is
+            // first displayed. Enable its background-input path before the first
+            // pointer event so the initial click can be forwarded to the session.
+            session?.SetUiActive(true);
             StartCaptureWorker();
         }
         catch (Exception exception)

--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -353,6 +353,12 @@ public class RdpClientView : UserControl, IDisposable
         {
             window.Activated += OnWindowActivated;
             window.Deactivated += OnWindowDeactivated;
+            if (window.IsActive)
+            {
+                // Register before the first pointer press so a fast initial
+                // keystroke cannot arrive before GotFocus installs the hook.
+                InstallKeyboardHook();
+            }
         }
 
         try
@@ -700,8 +706,7 @@ public class RdpClientView : UserControl, IDisposable
     private void OnWindowActivated(object? sender, EventArgs e)
     {
         session?.SetFrameActive(true);
-        if (IsKeyboardFocusWithin)
-            InstallKeyboardHook();
+        InstallKeyboardHook();
     }
 
     private void OnWindowDeactivated(object? sender, EventArgs e)

--- a/dotnet/MsRdpEx_AvaloniaApp/App.axaml.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/App.axaml.cs
@@ -16,15 +16,24 @@ public sealed class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             RdpLaunchOptions launchOptions = RdpLaunchOptions.Parse(desktop.Args ?? []);
-            ConnectionDialog connectionDialog = new(launchOptions);
-            connectionDialog.ConnectionRequested += settings =>
+            if (launchOptions.CanAutoConnect)
             {
-                MainWindow sessionWindow = new(settings, launchOptions);
-                desktop.MainWindow = sessionWindow;
-                sessionWindow.Show();
-                connectionDialog.Close();
-            };
-            desktop.MainWindow = connectionDialog;
+                desktop.MainWindow = new MainWindow(
+                    launchOptions.CreateConnectionSettings(),
+                    launchOptions);
+            }
+            else
+            {
+                ConnectionDialog connectionDialog = new(launchOptions);
+                connectionDialog.ConnectionRequested += settings =>
+                {
+                    MainWindow sessionWindow = new(settings, launchOptions);
+                    desktop.MainWindow = sessionWindow;
+                    sessionWindow.Show();
+                    connectionDialog.Close();
+                };
+                desktop.MainWindow = connectionDialog;
+            }
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml
+++ b/dotnet/MsRdpEx_AvaloniaApp/ConnectionDialog.axaml
@@ -7,6 +7,7 @@
     Width="630"
     Height="650"
     CanResize="False"
+    RequestedThemeVariant="Light"
     WindowStartupLocation="CenterScreen">
   <Grid RowDefinitions="112,*,Auto" Background="#F5F5F5">
     <Border

--- a/dotnet/MsRdpEx_AvaloniaApp/README.md
+++ b/dotnet/MsRdpEx_AvaloniaApp/README.md
@@ -58,6 +58,11 @@ and `--filename`; their `--RDP_*` forms are accepted as well. Supplying a
 password on a command line can expose it through process inspection, so the
 password field or `RDP_PASSWORD` should be preferred.
 
+When the resolved host, user, and password values are all present (including
+through `RDP_HOSTNAME`, `RDP_USERNAME`, and `RDP_PASSWORD`), the sample opens
+the RDP session directly without displaying the connection dialog. The password
+is passed in memory to the control and is not written to disk.
+
 ## Notes
 
 - The sample targets x64 Windows and Avalonia 12.1.1.

--- a/dotnet/MsRdpEx_AvaloniaApp/RdpLaunchOptions.cs
+++ b/dotnet/MsRdpEx_AvaloniaApp/RdpLaunchOptions.cs
@@ -15,6 +15,27 @@ internal sealed record RdpLaunchOptions(
     string AxName,
     string? RdpExDll)
 {
+    public bool CanAutoConnect =>
+        string.IsNullOrEmpty(Error) &&
+        !string.IsNullOrWhiteSpace(HostName) &&
+        !string.IsNullOrWhiteSpace(UserName) &&
+        !string.IsNullOrEmpty(Password);
+
+    public RdpConnectionSettings CreateConnectionSettings()
+    {
+        if (!CanAutoConnect)
+            throw new InvalidOperationException("Complete RDP credentials are required for automatic connection.");
+
+        return new RdpConnectionSettings(
+            HostName.Trim(),
+            UserName.Trim(),
+            Password,
+            Domain.Trim(),
+            DesktopWidth,
+            DesktopHeight,
+            RdpFileContents);
+    }
+
     public static RdpLaunchOptions Parse(IReadOnlyList<string> arguments)
     {
         return Parse(

--- a/dotnet/MsRdpEx_Test/RdpLaunchOptions.cs
+++ b/dotnet/MsRdpEx_Test/RdpLaunchOptions.cs
@@ -79,6 +79,44 @@ public sealed class RdpLaunchOptionsTests
     }
 
     [Fact]
+    public void CompleteEnvironmentCredentialsEnableAutomaticConnection()
+    {
+        Dictionary<string, string> environment = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["RDP_HOSTNAME"] = "environment-host",
+            ["RDP_USERNAME"] = "environment-user",
+            ["RDP_PASSWORD"] = "environment-password",
+            ["RDP_DOMAIN"] = "ENVIRONMENT-DOMAIN"
+        };
+
+        RdpLaunchOptions options = RdpLaunchOptions.Parse(
+            [], name => environment.GetValueOrDefault(name), _ => string.Empty);
+
+        Assert.True(options.CanAutoConnect);
+        var settings = options.CreateConnectionSettings();
+        Assert.Equal("environment-host", settings.HostName);
+        Assert.Equal("environment-user", settings.UserName);
+        Assert.Equal("environment-password", settings.Password);
+        Assert.Equal("ENVIRONMENT-DOMAIN", settings.Domain);
+    }
+
+    [Fact]
+    public void MissingPasswordKeepsTheConnectionDialog()
+    {
+        Dictionary<string, string> environment = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["RDP_HOSTNAME"] = "environment-host",
+            ["RDP_USERNAME"] = "environment-user"
+        };
+
+        RdpLaunchOptions options = RdpLaunchOptions.Parse(
+            [], name => environment.GetValueOrDefault(name), _ => string.Empty);
+
+        Assert.False(options.CanAutoConnect);
+        Assert.Throws<InvalidOperationException>(() => options.CreateConnectionSettings());
+    }
+
+    [Fact]
     public void ExplicitRdpFileOverridesEnvironmentAndPositionalFiles()
     {
         Dictionary<string, string> environment = new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- capture RDP ActiveX DirectX composition swap-chain frames before `Present` and feed them through the existing output-mirror/shadow-bitmap pipeline
- retain GDI capture as a guarded fallback when DirectX capture setup, frame production, or mirror upload fails
- harden capture lifecycle handling for device changes, resize, teardown, reconnects, and a single concurrent hardware-capture session

## Validation
- compiled all changed native C/C++ objects with the VsDevShell x64 environment
- the complete DLL target is blocked before linking because the repository lacks the generated `dll\version.rc` resource
- runtime validation still requires a hardware-mode RDP ActiveX session