### PR TITLE
Fixed issue when view is hidden and then re-shown

### DIFF
--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -76,6 +76,7 @@ public class RdpClientView : NativeControlHost, IDisposable
     private RdpDisplayMode displayMode = RdpDisplayMode.FitToWindow;
     private int zoomLevel = 100;
     private bool disposed;
+    private IPlatformHandle? detachedNativeControl;
 
     public RdpClientView()
     {
@@ -519,6 +520,16 @@ public class RdpClientView : NativeControlHost, IDisposable
         // leaves a fullscreen shell behind.
         ExitFullScreen();
         TeardownSession();
+
+        // NativeControlHost no longer tracks a control after its deferred
+        // destruction callback. If the view is still detached, release the
+        // retained HWND explicitly now that the owner has permanently closed
+        // the session.
+        if (detachedNativeControl is { } control)
+        {
+            detachedNativeControl = null;
+            base.DestroyNativeControlCore(control);
+        }
     }
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -583,6 +594,15 @@ public class RdpClientView : NativeControlHost, IDisposable
 
     protected override IPlatformHandle CreateNativeControlCore(IPlatformHandle parent)
     {
+        // Avalonia reparents the returned HWND into the new native host. Reuse
+        // the existing control so a docking or tab detach does not replace the
+        // connected ActiveX session with a fresh, unconfigured surface.
+        if (detachedNativeControl is { } control)
+        {
+            detachedNativeControl = null;
+            return control;
+        }
+
         nint window = CreateWindowExW(
             0,
             StaticWindowClass,
@@ -623,6 +643,16 @@ public class RdpClientView : NativeControlHost, IDisposable
 
     protected override void DestroyNativeControlCore(IPlatformHandle control)
     {
+        // NativeControlHost destroys controls that remain outside the visual
+        // tree past its short reparenting grace period. A docking tab can stay
+        // detached much longer, so retain its HWND until either it is attached
+        // again or the owning view is explicitly disposed.
+        if (!disposed)
+        {
+            detachedNativeControl = control;
+            return;
+        }
+
         // Release the OLE host while the window still exists; the base
         // implementation destroys the window itself afterwards.
         TeardownSession();

--- a/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
+++ b/dotnet/MsRdpEx_Test/AvaloniaHosting.cs
@@ -1,5 +1,8 @@
 using Devolutions.MsRdpEx.Avalonia;
 
+using Avalonia.Controls.Platform;
+using Avalonia.Platform;
+
 namespace MsRdpEx.Tests
 {
     public class AvaloniaHostingTests
@@ -110,6 +113,64 @@ namespace MsRdpEx.Tests
             // A now runs the inherited balance as the last session.
             RdpActiveXSession.EnterOleScope();
             Assert.True(RdpActiveXSession.ExitOleScope(true));
+        }
+
+        [Fact]
+        public void RdpClientViewReusesDetachedNativeControl()
+        {
+            using TestableRdpClientView view = new();
+            TestNativeControlHandle control = new();
+
+            view.DetachNativeControl(control);
+
+            Assert.False(control.IsDestroyed);
+            Assert.Same(control, view.AttachNativeControl(new TestPlatformHandle()));
+
+            view.Dispose();
+            view.DetachNativeControl(control);
+            Assert.True(control.IsDestroyed);
+        }
+
+        [Fact]
+        public void RdpClientViewDisposeDestroysDetachedNativeControl()
+        {
+            TestableRdpClientView view = new();
+            TestNativeControlHandle control = new();
+
+            view.DetachNativeControl(control);
+            view.Dispose();
+
+            Assert.True(control.IsDestroyed);
+        }
+
+        private sealed class TestableRdpClientView : RdpClientView
+        {
+            public IPlatformHandle AttachNativeControl(IPlatformHandle parent)
+            {
+                return base.CreateNativeControlCore(parent);
+            }
+
+            public void DetachNativeControl(IPlatformHandle control)
+            {
+                base.DestroyNativeControlCore(control);
+            }
+        }
+
+        private class TestPlatformHandle : IPlatformHandle
+        {
+            public nint Handle => 1;
+
+            public string HandleDescriptor => "TEST";
+        }
+
+        private sealed class TestNativeControlHandle : TestPlatformHandle, INativeControlHostDestroyableControlHandle
+        {
+            public bool IsDestroyed { get; private set; }
+
+            public void Destroy()
+            {
+                IsDestroyed = true;
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request improves how `RdpClientView` manages the lifecycle of its native control handle, especially when the control is temporarily detached (such as during docking or tab operations). The changes ensure that the native control (HWND) is not destroyed prematurely and is properly released when the view is disposed. The tests are updated to verify this new behavior.

**Improvements to native control lifecycle management:**

* Added a `detachedNativeControl` field to `RdpClientView` to retain the HWND when the control is detached but not disposed, preventing premature destruction during docking or tab detachment scenarios.
* Modified `DestroyNativeControlCore` to retain the native control in `detachedNativeControl` if the view is not disposed, and only destroy it when the view is explicitly disposed.
* Updated `CreateNativeControlCore` to reuse the retained `detachedNativeControl` when reattaching, ensuring the existing session is preserved instead of creating a new one.
* Updated `Dispose` to explicitly destroy the retained native control if it exists, ensuring proper cleanup when the view is disposed.

**Test coverage enhancements:**

* Added tests in `AvaloniaHosting.cs` to verify that `RdpClientView` properly reuses a detached native control and correctly destroys it upon disposal, preventing resource leaks or premature destruction.