### PR TITLE
Avalonia repaint

### DIFF
--- a/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
+++ b/dotnet/Devolutions.MsRdpEx.Avalonia/RdpClientView.cs
@@ -56,6 +56,11 @@ public class RdpClientView : NativeControlHost, IDisposable
     private const uint WsVisible = 0x10000000;
     private const uint WsClipSiblings = 0x04000000;
     private const uint WsTabStop = 0x00010000;
+    private const uint RdwInvalidate = 0x0001;
+    private const uint RdwErase = 0x0004;
+    private const uint RdwAllChildren = 0x0080;
+    private const uint RdwUpdateNow = 0x0100;
+    private const uint RdwFrame = 0x0400;
 
     private static readonly TimeSpan ResizeDebounceInterval = TimeSpan.FromMilliseconds(250);
 
@@ -77,6 +82,7 @@ public class RdpClientView : NativeControlHost, IDisposable
     private int zoomLevel = 100;
     private bool disposed;
     private IPlatformHandle? detachedNativeControl;
+    private bool refreshSurfaceOnNextArrange;
 
     public RdpClientView()
     {
@@ -549,6 +555,9 @@ public class RdpClientView : NativeControlHost, IDisposable
 
         base.OnAttachedToVisualTree(e);
 
+        if (refreshSurfaceOnNextArrange)
+            InvalidateArrange();
+
         // Reparenting to a new top level reuses the live session without
         // re-running StartSession, so re-apply the frame window and the
         // activation state on every attach, not just at session creation.
@@ -600,6 +609,7 @@ public class RdpClientView : NativeControlHost, IDisposable
         if (detachedNativeControl is { } control)
         {
             detachedNativeControl = null;
+            refreshSurfaceOnNextArrange = true;
             return control;
         }
 
@@ -662,7 +672,23 @@ public class RdpClientView : NativeControlHost, IDisposable
     protected override Size ArrangeOverride(Size finalSize)
     {
         Size arrangedSize = base.ArrangeOverride(finalSize);
+
+        bool refreshSurface = refreshSurfaceOnNextArrange;
+        refreshSurfaceOnNextArrange = false;
+        if (refreshSurface)
+            lastSurfaceSize = default;
+
         OnViewportChanged(arrangedSize);
+
+        if (refreshSurface && HostWindowHandle != 0)
+        {
+            RedrawWindow(
+                HostWindowHandle,
+                0,
+                0,
+                RdwInvalidate | RdwErase | RdwAllChildren | RdwUpdateNow | RdwFrame);
+        }
+
         return arrangedSize;
     }
 
@@ -916,4 +942,12 @@ public class RdpClientView : NativeControlHost, IDisposable
     [DllImport("user32.dll", ExactSpelling = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool EnableWindow(nint window, bool enable);
+
+    [DllImport("user32.dll", ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool RedrawWindow(
+        nint window,
+        nint updateRectangle,
+        nint updateRegion,
+        uint flags);
 }


### PR DESCRIPTION
This pull request improves the management of native window handles (`HWND`) in the `RdpClientView` Avalonia control, especially in scenarios involving docking, tab detachment, and disposal. It ensures that native resources are reused efficiently and released properly, preventing resource leaks and ensuring UI consistency. The changes are validated with new unit tests.

**Native control handle management and resource lifecycle:**

* The `RdpClientView` now retains the native control handle (`HWND`) when the control is temporarily detached (e.g., during docking or tab movement), and only destroys it when the view is explicitly disposed, avoiding premature destruction and unnecessary recreation. [[1]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR84-R85) [[2]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR529-R538) [[3]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR656-R665)
* The logic for creating and destroying native controls has been updated to check for existing detached handles and to trigger a surface refresh when reattaching, ensuring the UI remains consistent and responsive. [[1]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR606-R615) [[2]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR675-R691) [[3]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR558-R560)

**Surface refresh and redraw improvements:**

* Introduced flags and a P/Invoke for `RedrawWindow` to force a redraw of the native surface when necessary, preventing visual artifacts after reparenting or reattaching the control. [[1]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR59-R63) [[2]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR675-R691) [[3]](diffhunk://#diff-1025dcba8b5a1ce0d5383e95dce04851a1e24278512c3cc92a2c7f9c84316b1aR945-R952)

**Testing enhancements:**

* Added unit tests in `AvaloniaHosting.cs` to verify that detached native controls are reused correctly and destroyed only when appropriate, increasing confidence in the new lifecycle logic.

**Test infrastructure:**

* Introduced helper test classes (`TestableRdpClientView`, `TestNativeControlHandle`, `TestPlatformHandle`) to facilitate testing of native control attachment and detachment.

**Dependency updates:**

* Added missing `Avalonia.Controls.Platform` and `Avalonia.Platform` usings to the test file for platform handle interfaces.